### PR TITLE
Fix leak, prototype of a NetworkDiscovery abstraction

### DIFF
--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RecursiveDo #-}
+
+import Control.Monad (forM_, forM)
+import Data.String (fromString)
+import qualified Data.Set as S
+import qualified Data.ByteString.Char8 as B8
+import Node
+import qualified Network.Transport.TCP as TCP
+import Network.Transport.Concrete (concrete)
+import Network.Discovery.Abstract
+import qualified Network.Discovery.Transport.Kademlia as K
+import System.Environment (getArgs)
+import System.Random
+import qualified Control.Concurrent as Conc
+import qualified Control.Concurrent.STM.TChan as Conc
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent.MVar as Conc
+import qualified Control.Exception as Exception
+import Mockable.Class
+import Mockable.Concurrent
+import Mockable.SharedAtomic
+import Mockable.Channel
+import Mockable.Exception
+
+type instance ThreadId IO = Conc.ThreadId
+
+instance Mockable Fork IO where
+    liftMockable (Fork m) = Conc.forkIO m
+    liftMockable (MyThreadId) = Conc.myThreadId
+    liftMockable (KillThread tid) = Conc.killThread tid
+
+instance Mockable RunInUnboundThread IO where
+    liftMockable (RunInUnboundThread m) = Conc.runInUnboundThread m
+
+type instance SharedAtomicT IO = Conc.MVar
+
+instance Mockable SharedAtomic IO where
+    liftMockable (NewSharedAtomic t) = Conc.newMVar t
+    liftMockable (ModifySharedAtomic atomic f) = Conc.modifyMVar atomic f
+
+type instance ChannelT IO = Conc.TChan
+
+instance Mockable Channel IO where
+    liftMockable (NewChannel) = STM.atomically Conc.newTChan
+    liftMockable (ReadChannel channel) = STM.atomically $ Conc.readTChan channel
+    liftMockable (TryReadChannel channel) = STM.atomically $ Conc.tryReadTChan channel
+    liftMockable (WriteChannel channel t) = STM.atomically $ Conc.writeTChan channel t
+
+instance Mockable Bracket IO where
+    liftMockable (Bracket acquire release act) = Exception.bracket acquire release act
+
+instance Mockable Throw IO where
+    liftMockable (Throw e) = Exception.throwIO e
+
+workers :: ( RandomGen g ) => NodeId -> g -> NetworkDiscovery K.KademliaDiscoveryErrorCode IO -> [Worker IO]
+workers id gen discovery = [pingWorker gen]
+    where
+    pingWorker :: ( RandomGen g ) => g -> SendActions IO -> IO ()
+    pingWorker gen sendActions = loop gen
+        where
+        loop gen = do
+            let (i, gen') = randomR (1000,2000000) gen
+            --putStrLn (show id ++ " is waiting for " ++ show i ++ "us before discovering peers and sending pings")
+            Conc.threadDelay i
+            _ <- discoverPeers discovery
+            peerSet <- knownPeers discovery
+            putStrLn (show id ++ " has peer set: " ++ show peerSet)
+            forM_ (S.toList peerSet) (\addr -> sendTo sendActions (NodeId addr) (fromString "ping") ())
+            loop gen'
+
+listeners :: NodeId -> [Listener IO]
+listeners id = [Listener (fromString "ping") pongWorker]
+    where
+    pongWorker :: ListenerAction IO
+    pongWorker = ListenerActionOneMsg $ \peerId sendActions () -> do
+        putStrLn (show id ++  " heard a ping from " ++ show peerId)
+
+makeNode transport i = mdo
+    let port = 3000 + i
+    let host = "127.0.0.1"
+    let id = makeId i
+    let initialPeer =
+            if i == 0
+            -- First node uses itself as initial peer, else it'll panic because
+            -- its initial peer appears to be down.
+            then K.Node (K.Peer host (fromIntegral port)) id
+            else K.Node (K.Peer host (fromIntegral (port - 1))) (makeId (i - 1))
+    let kademliaConfig = K.KademliaConfiguration (fromIntegral port) id
+    let prng1 = mkStdGen (2 * i)
+    let prng2 = mkStdGen ((2 * i) + 1)
+    putStrLn $ "Starting node " ++ show i
+    node <- startNode transport prng1 (workers (nodeId node) prng2 discovery) (listeners (nodeId node))
+    let localAddress = nodeEndPointAddress node
+    putStrLn $ "Making discovery for node " ++ show i
+    discovery <- K.kademliaDiscovery kademliaConfig initialPeer localAddress
+    pure (node, discovery)
+    where
+    makeId i = B8.pack ("node_identifier_" ++ show i)
+
+main = mdo
+
+    [arg0] <- getArgs
+    let number = read arg0
+
+    Right transport_ <- TCP.createTransport ("127.0.0.1") ("10128") TCP.defaultTCPParameters
+    let transport = concrete transport_
+
+    putStrLn $ "Spawning " ++ show number ++ " nodes"
+    nodesAndDiscoveries <- forM [0..number] (makeNode transport)
+
+    putStrLn "Hit return to stop"
+    _ <- getChar
+
+    putStrLn "Stopping nodes"
+    forM_ nodesAndDiscoveries (\(n, d) -> stopNode n >> closeDiscovery d)

--- a/src/Mockable/Channel.hs
+++ b/src/Mockable/Channel.hs
@@ -8,6 +8,7 @@ module Mockable.Channel (
     , Channel(..)
     , newChannel
     , readChannel
+    , tryReadChannel
     , writeChannel
 
     ) where
@@ -17,8 +18,9 @@ import Mockable.Class
 type family ChannelT (m :: * -> *) :: * -> *
 
 data Channel (m :: * -> *) (t :: *) where
-    NewChannel   :: Channel m (ChannelT m t)
-    ReadChannel  :: ChannelT m t -> Channel m t
+    NewChannel :: Channel m (ChannelT m t)
+    ReadChannel :: ChannelT m t -> Channel m t
+    TryReadChannel :: ChannelT m t -> Channel m (Maybe t)
     WriteChannel :: ChannelT m t -> t -> Channel m ()
 
 newChannel :: ( Mockable Channel m ) => m (ChannelT m t)
@@ -26,6 +28,9 @@ newChannel = liftMockable NewChannel
 
 readChannel :: ( Mockable Channel m ) => ChannelT m t -> m t
 readChannel channel = liftMockable $ ReadChannel channel
+
+tryReadChannel :: ( Mockable Channel m ) => ChannelT m t -> m (Maybe t)
+tryReadChannel channel = liftMockable $ TryReadChannel channel
 
 writeChannel :: ( Mockable Channel m ) => ChannelT m t -> t -> m ()
 writeChannel channel t = liftMockable $ WriteChannel channel t

--- a/src/Mockable/Exception.hs
+++ b/src/Mockable/Exception.hs
@@ -11,6 +11,9 @@ module Mockable.Exception (
     , Throw(..)
     , throw
 
+    , Catch(..)
+    , catch
+
     ) where
 
 import Mockable.Class
@@ -27,3 +30,9 @@ data Throw (m :: * -> *) (t :: *) where
 
 throw :: ( Mockable Throw m ) => Exception e => e -> m t
 throw e = liftMockable $ Throw e
+
+data Catch (m :: * -> *) (t :: *) where
+    Catch :: Exception e => m t -> (e -> m t) -> Catch m t
+
+catch :: ( Mockable Catch m, Exception e ) => m t -> (e -> m t) -> m t
+catch action handler = liftMockable $ Catch action handler

--- a/src/Network/Discovery/Abstract.hs
+++ b/src/Network/Discovery/Abstract.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Network.Discovery.Abstract (
+
+      NetworkDiscovery(..)
+    , DiscoveryError(..)
+
+    ) where
+
+import GHC.Generics (Generic)
+import Control.Exception (Exception)
+import Data.Typeable (Typeable)
+import Data.Set (Set)
+import Network.Transport.Abstract (EndPointAddress)
+
+data NetworkDiscovery err m = NetworkDiscovery {
+      knownPeers :: m (Set EndPointAddress)
+    , discoverPeers :: m (Either (DiscoveryError err) (Set EndPointAddress))
+    -- ^ The set is the newly discovered peers (disjoint from 'knownPeers' at
+    -- the time it's used). Subsequent uses of 'knownPeers' should include these
+    -- new endpoints.
+    , closeDiscovery :: m ()
+    }
+
+data DiscoveryError error = DiscoveryError error String
+    deriving (Show, Typeable, Generic)
+
+instance (Typeable error, Show error) => Exception (DiscoveryError error)

--- a/src/Network/Discovery/Transport/InMemory.hs
+++ b/src/Network/Discovery/Transport/InMemory.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Network.Discovery.Transport.InMemory (
+
+      inMemoryDiscovery
+    , InMemoryDiscoveryErrorCode
+
+    ) where
+
+import GHC.Generics (Generic)
+import Data.Typeable (Typeable)
+import Data.Set (Set)
+import qualified Data.Set as S
+import qualified Data.Map as M
+import Network.Discovery.Abstract
+import Network.Transport
+import Network.Transport.InMemory
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent.STM.TVar as TVar
+import Control.Monad.IO.Class (MonadIO, liftIO)
+
+-- | An InMemory network transport can be used as a NetworkDiscovery. It takes
+--   addresses from the transport's internal state.
+inMemoryDiscovery
+    :: ( MonadIO m )
+    => TransportInternals
+    -> m (NetworkDiscovery InMemoryDiscoveryErrorCode m)
+inMemoryDiscovery internals = do
+    peersTVar <- liftIO . TVar.newTVarIO $ S.empty
+    let knownPeers = liftIO . TVar.readTVarIO $ peersTVar
+    let discoverPeers = liftIO . STM.atomically $ do
+            mAllPeers <- getPeersFromInternals internals
+            case mAllPeers of
+                Nothing -> pure (Left (DiscoveryError InMemoryDiscoveryTransportClosed "Transport is closed"))
+                Just allPeers -> do
+                    knownPeers <- TVar.readTVar peersTVar
+                    let newPeers = allPeers `S.difference` knownPeers
+                    TVar.writeTVar peersTVar allPeers
+                    pure (Right newPeers)
+    -- No need to do anything on close, since we don't exactly use any
+    -- resources.
+    let close = pure ()
+    pure $ NetworkDiscovery knownPeers discoverPeers close
+
+getPeersFromInternals :: TransportInternals -> STM.STM (Maybe (Set EndPointAddress))
+getPeersFromInternals (TransportInternals tvar) = do
+    state <- TVar.readTVar tvar
+    case state of
+        TransportValid (ValidTransportState map _) ->
+            pure . Just $ S.fromList (M.keys map)
+        TransportClosed -> pure Nothing
+
+data InMemoryDiscoveryErrorCode = InMemoryDiscoveryTransportClosed
+  deriving (Show, Typeable, Generic)

--- a/src/Network/Discovery/Transport/Kademlia.hs
+++ b/src/Network/Discovery/Transport/Kademlia.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Network.Discovery.Transport.Kademlia (
+
+      K.Node(..)
+    , K.Peer(..)
+    , KademliaConfiguration(..)
+    , kademliaDiscovery
+    , KademliaDiscoveryErrorCode(..)
+
+    ) where
+
+import GHC.Generics (Generic)
+import Control.Monad (forM)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Typeable (Typeable)
+import Data.Set (Set)
+import qualified Data.Set as S
+import qualified Data.Map.Strict as M
+import qualified Data.ByteString.Lazy as BL
+import Data.Word (Word16)
+import Data.Binary (encode, decodeOrFail, Binary)
+import Network.Discovery.Abstract
+import qualified Network.Kademlia as K
+import Network.Transport
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent.STM.TVar as TVar
+
+newtype KSerialize i = KSerialize i
+    deriving (Eq, Ord, Show)
+
+instance Binary i => K.Serialize (KSerialize i) where
+    fromBS bs = case decodeOrFail (BL.fromStrict bs) of
+        Left (_, _, str) -> Left str
+        Right (unconsumed, _, i) -> Right (KSerialize i, BL.toStrict unconsumed)
+    toBS (KSerialize i) = BL.toStrict . encode $ i
+
+data KademliaConfiguration i = KademliaConfiguration {
+      kademliaPort :: Word16
+    , kademliaId :: i
+    }
+
+-- | Discovery peers using the Kademlia DHT. Nodes in this network will store
+--   their (assumed to be TCP transport) 'EndPointAddress'es and send them
+--   over the wire on request. NB there are two notions of ID here: the
+--   Kademlia IDs, and the 'EndPointAddress'es which are indexed by the former.
+kademliaDiscovery
+    :: forall m i .
+       ( MonadIO m, Binary i, Ord i )
+    => KademliaConfiguration i
+    -> K.Node i
+    -- ^ A known peer, necessary in order to join the network.
+    -> EndPointAddress
+    -- ^ My address. Will store it in the DHT.
+    -> m (NetworkDiscovery KademliaDiscoveryErrorCode m)
+kademliaDiscovery configuration initialPeer myAddress = do
+    let kid :: KSerialize i
+        kid = KSerialize (kademliaId configuration)
+    let port :: Int
+        port = fromIntegral (kademliaPort configuration)
+    kademliaInst :: K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+        <- liftIO $ K.create port kid
+    peersTVar :: TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+        <- liftIO . TVar.newTVarIO $ M.empty
+    let knownPeers = fmap (S.fromList . M.elems) . liftIO . TVar.readTVarIO $ peersTVar
+    let discoverPeers = liftIO $ kademliaDiscoverPeers kademliaInst peersTVar
+    let close = liftIO $ K.close kademliaInst
+    liftIO $ kademliaJoinAndUpdate kademliaInst peersTVar initialPeer
+    () <- liftIO $ K.store kademliaInst kid (KSerialize myAddress)
+    pure $ NetworkDiscovery knownPeers discoverPeers close
+
+
+kademliaDiscoverPeers
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+    -> IO (Either (DiscoveryError KademliaDiscoveryErrorCode) (S.Set EndPointAddress))
+kademliaDiscoverPeers kademliaInst peersTVar = do
+    recordedPeers <- TVar.readTVarIO peersTVar
+    currentPeers <- K.dumpPeers kademliaInst
+    -- The idea is to always update the TVar to the set of nodes in allPeers,
+    -- but only lookup the addresses for nodes which are not in the recorded
+    -- set to begin with.
+    currentWithAddresses <- fmap (M.mapMaybe id) (kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers)
+    STM.atomically $ TVar.writeTVar peersTVar currentWithAddresses
+    let new = currentWithAddresses `M.difference` recordedPeers
+    pure $ Right (S.fromList (M.elems new))
+
+kademliaJoinAndUpdate
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+    -> K.Node i
+    -> IO (Either (DiscoveryError KademliaDiscoveryErrorCode) (S.Set EndPointAddress))
+kademliaJoinAndUpdate kademliaInst peersTVar initialPeer = do
+    result <- K.joinNetwork kademliaInst initialPeer'
+    case result of
+        K.IDClash -> pure $ Left (DiscoveryError KademliaIdClash "ID clash in network")
+        K.NodeDown -> pure $ Left (DiscoveryError KademliaInitialPeerDown "Initial peer is down")
+        -- [sic]
+        K.JoinSucces -> do
+            peerList <- K.dumpPeers kademliaInst
+            -- We have the peers, but we do not have the 'EndPointAddress'es for
+            -- them. We must ask the network for them.
+            endPointAddresses <- fmap (M.mapMaybe id) (kademliaLookupEndPointAddresses kademliaInst M.empty peerList)
+            STM.atomically $ TVar.writeTVar peersTVar endPointAddresses
+            pure $ Right (S.fromList (M.elems endPointAddresses))
+    where
+    initialPeer' :: K.Node (KSerialize i)
+    initialPeer' = case initialPeer of
+        K.Node peer id -> K.Node peer (KSerialize id)
+
+kademliaLookupEndPointAddresses
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> M.Map (K.Node (KSerialize i)) EndPointAddress
+    -> [K.Node (KSerialize i)]
+    -> IO (M.Map (K.Node (KSerialize i)) (Maybe EndPointAddress))
+kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers = do
+    -- TODO do this in parallel, as each one may induce a blocking lookup.
+    endPointAddresses <- forM currentPeers (kademliaLookupEndPointAddress kademliaInst recordedPeers)
+    let assoc :: [(K.Node (KSerialize i), Maybe EndPointAddress)]
+        assoc = zip currentPeers endPointAddresses
+    pure $ M.fromList assoc
+  where
+  isJust (Just _) = True
+  isJust _ = False
+
+kademliaLookupEndPointAddress
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> M.Map (K.Node (KSerialize i)) EndPointAddress
+    -> K.Node (KSerialize i)
+    -> IO (Maybe EndPointAddress)
+kademliaLookupEndPointAddress kademliaInst recordedPeers peer@(K.Node _ id) =
+    case M.lookup peer recordedPeers of
+        Nothing -> do
+            outcome <- K.lookup kademliaInst id
+            pure $ case outcome of
+                Nothing -> Nothing
+                Just (KSerialize endPointAddress, _) -> Just endPointAddress
+        Just address -> pure (Just address)
+
+data KademliaDiscoveryErrorCode
+    = KademliaIdClash
+    | KademliaInitialPeerDown
+    deriving (Show, Typeable, Generic)

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -108,7 +108,8 @@ makeListenerIndex = foldr combine (M.empty, [])
 startNode
     :: forall m .
        ( Mockable Fork m, Mockable Throw m, Mockable Channel m
-       , Mockable SharedAtomic m, Mockable Bracket m, MonadFix m )
+       , Mockable SharedAtomic m, Mockable Bracket m, Mockable Catch m
+       , MonadFix m )
     => NT.Transport m
     -> StdGen
     -> [Worker m]


### PR DESCRIPTION
Quick fix to dispatcher so that the state map doesn't grow without
bound. It's a naive solution: clean up all finished threads and then
receive. It's probably not ideal for throughput.

NetworkDiscovery:

Find an InMemory instantiation (which requires a patch to
network-transport-inmemory that's up as a pull request currently) as
well as one backed by Kademlia. There's also an example where you can
spin up locally as many nodes as you want. They'll use a TCP transport
and Kademlia to discover each-other's end point addresses and then send
pings at random intervals.