### PR TITLE
Avieth/discovery

### DIFF
--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RecursiveDo #-}
+
+import Control.Monad (forM_, forM)
+import Data.String (fromString)
+import qualified Data.Set as S
+import qualified Data.ByteString.Char8 as B8
+import Node
+import qualified Network.Transport.TCP as TCP
+import Network.Transport.Concrete (concrete)
+import Network.Discovery.Abstract
+import qualified Network.Discovery.Transport.Kademlia as K
+import System.Environment (getArgs)
+import System.Random
+import qualified Control.Concurrent as Conc
+import qualified Control.Concurrent.STM.TChan as Conc
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent.MVar as Conc
+import qualified Control.Exception as Exception
+import Mockable.Class
+import Mockable.Concurrent
+import Mockable.SharedAtomic
+import Mockable.Channel
+import Mockable.Exception
+
+type instance ThreadId IO = Conc.ThreadId
+
+instance Mockable Fork IO where
+    liftMockable (Fork m) = Conc.forkIO m
+    liftMockable (MyThreadId) = Conc.myThreadId
+    liftMockable (KillThread tid) = Conc.killThread tid
+
+instance Mockable RunInUnboundThread IO where
+    liftMockable (RunInUnboundThread m) = Conc.runInUnboundThread m
+
+type instance SharedAtomicT IO = Conc.MVar
+
+instance Mockable SharedAtomic IO where
+    liftMockable (NewSharedAtomic t) = Conc.newMVar t
+    liftMockable (ModifySharedAtomic atomic f) = Conc.modifyMVar atomic f
+
+type instance ChannelT IO = Conc.TChan
+
+instance Mockable Channel IO where
+    liftMockable (NewChannel) = STM.atomically Conc.newTChan
+    liftMockable (ReadChannel channel) = STM.atomically $ Conc.readTChan channel
+    liftMockable (TryReadChannel channel) = STM.atomically $ Conc.tryReadTChan channel
+    liftMockable (WriteChannel channel t) = STM.atomically $ Conc.writeTChan channel t
+
+instance Mockable Bracket IO where
+    liftMockable (Bracket acquire release act) = Exception.bracket acquire release act
+
+instance Mockable Throw IO where
+    liftMockable (Throw e) = Exception.throwIO e
+
+workers :: ( RandomGen g ) => NodeId -> g -> NetworkDiscovery K.KademliaDiscoveryErrorCode IO -> [Worker IO]
+workers id gen discovery = [pingWorker gen]
+    where
+    pingWorker :: ( RandomGen g ) => g -> SendActions IO -> IO ()
+    pingWorker gen sendActions = loop gen
+        where
+        loop gen = do
+            let (i, gen') = randomR (1000,2000000) gen
+            --putStrLn (show id ++ " is waiting for " ++ show i ++ "us before discovering peers and sending pings")
+            Conc.threadDelay i
+            _ <- discoverPeers discovery
+            peerSet <- knownPeers discovery
+            putStrLn (show id ++ " has peer set: " ++ show peerSet)
+            forM_ (S.toList peerSet) (\addr -> sendTo sendActions (NodeId addr) (fromString "ping") ())
+            loop gen'
+
+listeners :: NodeId -> [Listener IO]
+listeners id = [Listener (fromString "ping") pongWorker]
+    where
+    pongWorker :: ListenerAction IO
+    pongWorker = ListenerActionOneMsg $ \peerId sendActions () -> do
+        putStrLn (show id ++  " heard a ping from " ++ show peerId)
+
+makeNode transport i = mdo
+    let port = 3000 + i
+    let host = "127.0.0.1"
+    let id = makeId i
+    let initialPeer =
+            if i == 0
+            -- First node uses itself as initial peer, else it'll panic because
+            -- its initial peer appears to be down.
+            then K.Node (K.Peer host (fromIntegral port)) id
+            else K.Node (K.Peer host (fromIntegral (port - 1))) (makeId (i - 1))
+    let kademliaConfig = K.KademliaConfiguration (fromIntegral port) id
+    let prng1 = mkStdGen (2 * i)
+    let prng2 = mkStdGen ((2 * i) + 1)
+    putStrLn $ "Starting node " ++ show i
+    node <- startNode transport prng1 (workers (nodeId node) prng2 discovery) (listeners (nodeId node))
+    let localAddress = nodeEndPointAddress node
+    putStrLn $ "Making discovery for node " ++ show i
+    discovery <- K.kademliaDiscovery kademliaConfig initialPeer localAddress
+    pure (node, discovery)
+    where
+    makeId i = B8.pack ("node_identifier_" ++ show i)
+
+main = mdo
+
+    [arg0] <- getArgs
+    let number = read arg0
+
+    Right transport_ <- TCP.createTransport ("127.0.0.1") ("10128") TCP.defaultTCPParameters
+    let transport = concrete transport_
+
+    putStrLn $ "Spawning " ++ show number ++ " nodes"
+    nodesAndDiscoveries <- forM [0..number] (makeNode transport)
+
+    putStrLn "Hit return to stop"
+    _ <- getChar
+
+    putStrLn "Stopping nodes"
+    forM_ nodesAndDiscoveries (\(n, d) -> stopNode n >> closeDiscovery d)

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -48,8 +48,10 @@ workers id gen discovery = [pingWorker gen]
             liftIO . putStrLn $ show id ++ " has peer set: " ++ show peerSet
             forM_ (S.toList peerSet) $ \addr -> withConnectionTo sendActions (NodeId addr) (fromString "ping") $
                 \(cactions :: ConversationActions Void Pong Production) -> do
-                    Pong <- recv cactions
-                    liftIO . putStrLn $ show id ++ " heard PONG from " ++ show addr
+                    received <- recv cactions
+                    case received of
+                        Just Pong -> liftIO . putStrLn $ show id ++ " heard PONG from " ++ show addr
+                        Nothing -> error "Unexpected end of input"
             loop gen'
 
 listeners :: NodeId -> [Listener Production]

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -48,6 +48,7 @@ instance Mockable Channel IO where
     liftMockable (NewChannel) = STM.atomically Conc.newTChan
     liftMockable (ReadChannel channel) = STM.atomically $ Conc.readTChan channel
     liftMockable (TryReadChannel channel) = STM.atomically $ Conc.tryReadTChan channel
+    liftMockable (UnGetChannel channel t) = STM.atomically $ Conc.unGetTChan channel t
     liftMockable (WriteChannel channel t) = STM.atomically $ Conc.writeTChan channel t
 
 instance Mockable Bracket IO where

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -3,17 +3,25 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
+import GHC.Generics (Generic)
 import Control.Monad (forM_)
 import Data.String (fromString)
+import Data.Proxy (Proxy(..))
+import Data.Void (Void)
+import Data.Binary
 import Node
 import qualified Network.Transport.TCP as TCP
 import qualified Network.Transport.InMemory as InMemory
 import Network.Transport.Concrete (concrete)
 import System.Random
 import qualified Control.Concurrent as Conc
-import qualified Control.Concurrent.Chan as Conc
 import qualified Control.Concurrent.MVar as Conc
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent.STM.TChan as Conc
 import qualified Control.Exception as Exception
 import Mockable.Class
 import Mockable.Concurrent
@@ -37,12 +45,14 @@ instance Mockable SharedAtomic IO where
     liftMockable (NewSharedAtomic t) = Conc.newMVar t
     liftMockable (ModifySharedAtomic atomic f) = Conc.modifyMVar atomic f
 
-type instance ChannelT IO = Conc.Chan
+type instance ChannelT IO = Conc.TChan
 
 instance Mockable Channel IO where
-    liftMockable (NewChannel) = Conc.newChan
-    liftMockable (ReadChannel channel) = Conc.readChan channel
-    liftMockable (WriteChannel channel t) = Conc.writeChan channel t
+    liftMockable (NewChannel) = STM.atomically Conc.newTChan
+    liftMockable (ReadChannel channel) = STM.atomically $ Conc.readTChan channel
+    liftMockable (TryReadChannel channel) = STM.atomically $ Conc.tryReadTChan channel
+    liftMockable (UnGetChannel channel t) = STM.atomically $ Conc.unGetTChan channel t
+    liftMockable (WriteChannel channel t) = STM.atomically $ Conc.writeTChan channel t
 
 instance Mockable Bracket IO where
     liftMockable (Bracket acquire release act) = Exception.bracket acquire release act
@@ -50,25 +60,64 @@ instance Mockable Bracket IO where
 instance Mockable Throw IO where
     liftMockable (Throw e) = Exception.throwIO e
 
-workers :: ( RandomGen g ) => NodeId -> g -> [NodeId] -> [Worker IO]
+instance Mockable Catch IO where
+    liftMockable (Catch action handler) = action `Exception.catch` handler
+
+-- Sending a message which encodes to "" is problematic!
+-- The receiver can't distinuish this from the case in which the sender sent
+-- nothing at all.
+-- So we give custom Ping and Pong types with non-generic Binary instances.
+--
+-- TBD should we fix this in network-transport? Maybe every chunk is prefixed
+-- by a byte giving its length? Wasteful I guess but maybe not a problem.
+
+data Ping = Ping
+deriving instance Show Ping
+instance Binary Ping where
+    put _ = putWord8 (fromIntegral 0)
+    get = do
+        w <- getWord8
+        if w == fromIntegral 0
+        then pure Ping
+        else fail "no parse ping"
+
+data Pong = Pong
+deriving instance Show Pong
+instance Binary Pong where
+    put _ = putWord8 (fromIntegral 1)
+    get = do
+        w <- getWord8
+        if w == fromIntegral 1
+        then pure Pong
+        else fail "no parse pong"
+
+workers :: NodeId -> StdGen -> [NodeId] -> [Worker IO]
 workers id gen peerIds = [pingWorker gen]
     where
-    pingWorker :: ( RandomGen g ) => g -> SendActions IO -> IO ()
+    pingWorker :: StdGen -> SendActions IO -> IO ()
     pingWorker gen sendActions = loop gen
         where
+        loop :: StdGen -> IO ()
         loop gen = do
             let (i, gen') = randomR (0,1000000) gen
-            putStrLn (show id ++ " is waiting for " ++ show i ++ "us before sending pings")
+            --putStrLn (show id ++ " is waiting for " ++ show i ++ "us before sending pings")
             Conc.threadDelay i
-            forM_ peerIds (\peerId -> sendTo sendActions peerId (fromString "ping") ())
+            let pong :: NodeId -> ConversationActions Void Pong IO -> IO ()
+                pong peerId cactions = do
+                    putStrLn (show id ++ " sent PING to " ++ show peerId)
+                    Pong <- recv cactions
+                    putStrLn (show id ++ " heard PONG from " ++ show peerId)
+            forM_ peerIds $ \peerId -> withConnectionTo sendActions peerId (fromString "ping") (pong peerId)
             loop gen'
 
 listeners :: NodeId -> [Listener IO]
 listeners id = [Listener (fromString "ping") pongWorker]
     where
     pongWorker :: ListenerAction IO
-    pongWorker = ListenerActionOneMsg $ \peerId sendActions () -> do
-        putStrLn (show id ++  " heard a pong from " ++ show peerId)
+    pongWorker = ListenerActionConversation $ \peerId (cactions :: ConversationActions Pong Void IO) -> do
+        putStrLn (show id ++  " heard PING from " ++ show peerId)
+        send cactions Pong
+        putStrLn (show id ++ " sent PONG to " ++ show peerId)
 
 main = mdo
 

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -50,8 +50,10 @@ workers id gen peerIds = [pingWorker gen]
             let pong :: NodeId -> ConversationActions Void Pong Production -> Production ()
                 pong peerId cactions = do
                     liftIO . putStrLn $ show id ++ " sent PING to " ++ show peerId
-                    Pong <- recv cactions
-                    liftIO . putStrLn $ show id ++ " heard PONG from " ++ show peerId
+                    received <- recv cactions
+                    case received of
+                        Just Pong -> liftIO . putStrLn $ show id ++ " heard PONG from " ++ show peerId
+                        Nothing -> error "Unexpected end of input"
             forM_ peerIds $ \peerId -> withConnectionTo sendActions peerId (fromString "ping") (pong peerId)
             loop gen'
 

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -4,13 +4,11 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
-import GHC.Generics (Generic)
 import Control.Monad (forM_)
+import Control.Monad.IO.Class (liftIO)
 import Data.String (fromString)
-import Data.Proxy (Proxy(..))
 import Data.Void (Void)
 import Data.Binary
 import Node
@@ -18,50 +16,8 @@ import qualified Network.Transport.TCP as TCP
 import qualified Network.Transport.InMemory as InMemory
 import Network.Transport.Concrete (concrete)
 import System.Random
-import qualified Control.Concurrent as Conc
-import qualified Control.Concurrent.MVar as Conc
-import qualified Control.Concurrent.STM as STM
-import qualified Control.Concurrent.STM.TChan as Conc
-import qualified Control.Exception as Exception
-import Mockable.Class
-import Mockable.Concurrent
-import Mockable.SharedAtomic
-import Mockable.Channel
-import Mockable.Exception
-
-type instance ThreadId IO = Conc.ThreadId
-
-instance Mockable Fork IO where
-    liftMockable (Fork m) = Conc.forkIO m
-    liftMockable (MyThreadId) = Conc.myThreadId
-    liftMockable (KillThread tid) = Conc.killThread tid
-
-instance Mockable RunInUnboundThread IO where
-    liftMockable (RunInUnboundThread m) = Conc.runInUnboundThread m
-
-type instance SharedAtomicT IO = Conc.MVar
-
-instance Mockable SharedAtomic IO where
-    liftMockable (NewSharedAtomic t) = Conc.newMVar t
-    liftMockable (ModifySharedAtomic atomic f) = Conc.modifyMVar atomic f
-
-type instance ChannelT IO = Conc.TChan
-
-instance Mockable Channel IO where
-    liftMockable (NewChannel) = STM.atomically Conc.newTChan
-    liftMockable (ReadChannel channel) = STM.atomically $ Conc.readTChan channel
-    liftMockable (TryReadChannel channel) = STM.atomically $ Conc.tryReadTChan channel
-    liftMockable (UnGetChannel channel t) = STM.atomically $ Conc.unGetTChan channel t
-    liftMockable (WriteChannel channel t) = STM.atomically $ Conc.writeTChan channel t
-
-instance Mockable Bracket IO where
-    liftMockable (Bracket acquire release act) = Exception.bracket acquire release act
-
-instance Mockable Throw IO where
-    liftMockable (Throw e) = Exception.throwIO e
-
-instance Mockable Catch IO where
-    liftMockable (Catch action handler) = action `Exception.catch` handler
+import Mockable.Concurrent (delay)
+import Mockable.Production
 
 -- Sending a message which encodes to "" is problematic!
 -- The receiver can't distinuish this from the case in which the sender sent
@@ -91,38 +47,37 @@ instance Binary Pong where
         then pure Pong
         else fail "no parse pong"
 
-workers :: NodeId -> StdGen -> [NodeId] -> [Worker IO]
+workers :: NodeId -> StdGen -> [NodeId] -> [Worker Production]
 workers id gen peerIds = [pingWorker gen]
     where
-    pingWorker :: StdGen -> SendActions IO -> IO ()
+    pingWorker :: StdGen -> SendActions Production -> Production ()
     pingWorker gen sendActions = loop gen
         where
-        loop :: StdGen -> IO ()
+        loop :: StdGen -> Production ()
         loop gen = do
             let (i, gen') = randomR (0,1000000) gen
-            --putStrLn (show id ++ " is waiting for " ++ show i ++ "us before sending pings")
-            Conc.threadDelay i
-            let pong :: NodeId -> ConversationActions Void Pong IO -> IO ()
+            delay i
+            let pong :: NodeId -> ConversationActions Void Pong Production -> Production ()
                 pong peerId cactions = do
-                    putStrLn (show id ++ " sent PING to " ++ show peerId)
+                    liftIO . putStrLn $ show id ++ " sent PING to " ++ show peerId
                     Pong <- recv cactions
-                    putStrLn (show id ++ " heard PONG from " ++ show peerId)
+                    liftIO . putStrLn $ show id ++ " heard PONG from " ++ show peerId
             forM_ peerIds $ \peerId -> withConnectionTo sendActions peerId (fromString "ping") (pong peerId)
             loop gen'
 
-listeners :: NodeId -> [Listener IO]
+listeners :: NodeId -> [Listener Production]
 listeners id = [Listener (fromString "ping") pongWorker]
     where
-    pongWorker :: ListenerAction IO
-    pongWorker = ListenerActionConversation $ \peerId (cactions :: ConversationActions Pong Void IO) -> do
-        putStrLn (show id ++  " heard PING from " ++ show peerId)
+    pongWorker :: ListenerAction Production
+    pongWorker = ListenerActionConversation $ \peerId (cactions :: ConversationActions Pong Void Production) -> do
+        liftIO . putStrLn $ show id ++  " heard PING from " ++ show peerId
         send cactions Pong
-        putStrLn (show id ++ " sent PONG to " ++ show peerId)
+        liftIO . putStrLn $ show id ++ " sent PONG to " ++ show peerId
 
-main = mdo
+main = runProduction $ do
 
     --transport_ <- InMemory.createTransport
-    Right transport_ <- TCP.createTransport ("127.0.0.1") ("10128") TCP.defaultTCPParameters
+    Right transport_ <- liftIO $ TCP.createTransport ("127.0.0.1") ("10128") TCP.defaultTCPParameters
     let transport = concrete transport_
 
     let prng1 = mkStdGen 0
@@ -130,16 +85,16 @@ main = mdo
     let prng3 = mkStdGen 2
     let prng4 = mkStdGen 3
 
-    putStrLn "Starting nodes"
+    liftIO . putStrLn $ "Starting nodes"
     rec { node1 <- startNode transport prng1 (workers nodeId1 prng2 [nodeId2]) (listeners nodeId1)
         ; node2 <- startNode transport prng3 (workers nodeId2 prng4 [nodeId1]) (listeners nodeId2)
         ; let nodeId1 = nodeId node1
         ; let nodeId2 = nodeId node2
         }
 
-    putStrLn "Hit return to stop"
-    _ <- getChar
+    liftIO . putStrLn $ "Hit return to stop"
+    _ <- liftIO getChar
 
-    putStrLn "Stopping node"
+    liftIO . putStrLn $ "Stopping node"
     stopNode node1
     stopNode node2

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -27,16 +27,6 @@ import Mockable.Production
 -- TBD should we fix this in network-transport? Maybe every chunk is prefixed
 -- by a byte giving its length? Wasteful I guess but maybe not a problem.
 
-data Ping = Ping
-deriving instance Show Ping
-instance Binary Ping where
-    put _ = putWord8 (fromIntegral 0)
-    get = do
-        w <- getWord8
-        if w == fromIntegral 0
-        then pure Ping
-        else fail "no parse ping"
-
 data Pong = Pong
 deriving instance Show Pong
 instance Binary Pong where

--- a/src/Mockable/Channel.hs
+++ b/src/Mockable/Channel.hs
@@ -9,6 +9,7 @@ module Mockable.Channel (
     , newChannel
     , readChannel
     , tryReadChannel
+    , unGetChannel
     , writeChannel
 
     ) where
@@ -21,6 +22,7 @@ data Channel (m :: * -> *) (t :: *) where
     NewChannel :: Channel m (ChannelT m t)
     ReadChannel :: ChannelT m t -> Channel m t
     TryReadChannel :: ChannelT m t -> Channel m (Maybe t)
+    UnGetChannel :: ChannelT m t -> t -> Channel m ()
     WriteChannel :: ChannelT m t -> t -> Channel m ()
 
 newChannel :: ( Mockable Channel m ) => m (ChannelT m t)
@@ -31,6 +33,9 @@ readChannel channel = liftMockable $ ReadChannel channel
 
 tryReadChannel :: ( Mockable Channel m ) => ChannelT m t -> m (Maybe t)
 tryReadChannel channel = liftMockable $ TryReadChannel channel
+
+unGetChannel :: ( Mockable Channel m ) => ChannelT m t -> t -> m ()
+unGetChannel channel t = liftMockable $ UnGetChannel channel t
 
 writeChannel :: ( Mockable Channel m ) => ChannelT m t -> t -> m ()
 writeChannel channel t = liftMockable $ WriteChannel channel t

--- a/src/Mockable/Channel.hs
+++ b/src/Mockable/Channel.hs
@@ -8,6 +8,7 @@ module Mockable.Channel (
     , Channel(..)
     , newChannel
     , readChannel
+    , tryReadChannel
     , writeChannel
 
     ) where
@@ -17,8 +18,9 @@ import Mockable.Class
 type family ChannelT (m :: * -> *) :: * -> *
 
 data Channel (m :: * -> *) (t :: *) where
-    NewChannel   :: Channel m (ChannelT m t)
-    ReadChannel  :: ChannelT m t -> Channel m t
+    NewChannel :: Channel m (ChannelT m t)
+    ReadChannel :: ChannelT m t -> Channel m t
+    TryReadChannel :: ChannelT m t -> Channel m (Maybe t)
     WriteChannel :: ChannelT m t -> t -> Channel m ()
 
 newChannel :: ( Mockable Channel m ) => m (ChannelT m t)
@@ -26,6 +28,9 @@ newChannel = liftMockable NewChannel
 
 readChannel :: ( Mockable Channel m ) => ChannelT m t -> m t
 readChannel channel = liftMockable $ ReadChannel channel
+
+tryReadChannel :: ( Mockable Channel m ) => ChannelT m t -> m (Maybe t)
+tryReadChannel channel = liftMockable $ TryReadChannel channel
 
 writeChannel :: ( Mockable Channel m ) => ChannelT m t -> t -> m ()
 writeChannel channel t = liftMockable $ WriteChannel channel t

--- a/src/Mockable/Concurrent.hs
+++ b/src/Mockable/Concurrent.hs
@@ -11,6 +11,9 @@ module Mockable.Concurrent (
   , myThreadId
   , killThread
 
+  , Delay(..)
+  , delay
+
   , RunInUnboundThread(..)
   , runInUnboundThread
 
@@ -33,6 +36,13 @@ myThreadId = liftMockable MyThreadId
 
 killThread :: ( Mockable Fork m ) => ThreadId m -> m ()
 killThread tid = liftMockable $ KillThread tid
+
+data Delay (m :: * -> *) (t :: *) where
+    -- | Delay in microseconds
+    Delay :: Int -> Delay m ()
+
+delay :: ( Mockable Delay m ) => Int -> m ()
+delay us = liftMockable $ Delay us
 
 data RunInUnboundThread m t where
     RunInUnboundThread :: m t -> RunInUnboundThread m t

--- a/src/Mockable/Exception.hs
+++ b/src/Mockable/Exception.hs
@@ -11,6 +11,9 @@ module Mockable.Exception (
     , Throw(..)
     , throw
 
+    , Catch(..)
+    , catch
+
     ) where
 
 import Mockable.Class
@@ -27,3 +30,9 @@ data Throw (m :: * -> *) (t :: *) where
 
 throw :: ( Mockable Throw m ) => Exception e => e -> m t
 throw e = liftMockable $ Throw e
+
+data Catch (m :: * -> *) (t :: *) where
+    Catch :: Exception e => m t -> (e -> m t) -> Catch m t
+
+catch :: ( Mockable Catch m, Exception e ) => m t -> (e -> m t) -> m t
+catch action handler = liftMockable $ Catch action handler

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Mockable.Production where
+
+import Mockable.Class
+import Mockable.Concurrent
+import Mockable.SharedAtomic
+import Mockable.Channel
+import Mockable.Exception
+import Control.Monad.Fix (MonadFix)
+import Control.Monad.IO.Class (MonadIO)
+import qualified Control.Exception as Exception
+import qualified Control.Concurrent as Conc
+import qualified Control.Concurrent.MVar as Conc
+import qualified Control.Concurrent.STM as Conc
+import qualified Control.Concurrent.STM.TChan as Conc
+
+newtype Production t = Production {
+    runProduction :: IO t
+  }
+
+deriving instance Functor Production
+deriving instance Applicative Production
+deriving instance Monad Production
+deriving instance MonadIO Production
+deriving instance MonadFix Production
+
+type instance ThreadId Production = Conc.ThreadId
+
+instance Mockable Fork Production where
+    liftMockable (Fork m) = Production $ Conc.forkIO (runProduction m)
+    liftMockable (MyThreadId) = Production $ Conc.myThreadId
+    liftMockable (KillThread tid) = Production $ Conc.killThread tid
+
+instance Mockable Delay Production where
+    liftMockable (Delay us) = Production $ Conc.threadDelay us
+
+instance Mockable RunInUnboundThread Production where
+    liftMockable (RunInUnboundThread m) = Production $
+        Conc.runInUnboundThread (runProduction m)
+
+type instance SharedAtomicT Production = Conc.MVar
+
+instance Mockable SharedAtomic Production where
+    liftMockable (NewSharedAtomic t) = Production $ Conc.newMVar t
+    liftMockable (ModifySharedAtomic atomic f) = Production $ Conc.modifyMVar atomic (runProduction . f)
+
+type instance ChannelT Production = Conc.TChan
+
+instance Mockable Channel Production where
+    liftMockable (NewChannel) = Production . Conc.atomically $ Conc.newTChan
+    liftMockable (ReadChannel channel) = Production . Conc.atomically $ Conc.readTChan channel
+    liftMockable (TryReadChannel channel) = Production . Conc.atomically $ Conc.tryReadTChan channel
+    liftMockable (UnGetChannel channel t) = Production . Conc.atomically $ Conc.unGetTChan channel t
+    liftMockable (WriteChannel channel t) = Production . Conc.atomically $ Conc.writeTChan channel t
+
+instance Mockable Bracket Production where
+    liftMockable (Bracket acquire release act) = Production $
+        Exception.bracket (runProduction acquire) (runProduction . release) (runProduction . act)
+
+instance Mockable Throw Production where
+    liftMockable (Throw e) = Production $ Exception.throwIO e
+
+instance Mockable Catch Production where
+    liftMockable (Catch action handler) = Production $
+        runProduction action `Exception.catch` (runProduction . handler)

--- a/src/Network/Discovery/Abstract.hs
+++ b/src/Network/Discovery/Abstract.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Network.Discovery.Abstract (
+
+      NetworkDiscovery(..)
+    , DiscoveryError(..)
+
+    ) where
+
+import GHC.Generics (Generic)
+import Control.Exception (Exception)
+import Data.Typeable (Typeable)
+import Data.Set (Set)
+import Network.Transport.Abstract (EndPointAddress)
+
+data NetworkDiscovery err m = NetworkDiscovery {
+      knownPeers :: m (Set EndPointAddress)
+    , discoverPeers :: m (Either (DiscoveryError err) (Set EndPointAddress))
+    -- ^ The set is the newly discovered peers (disjoint from 'knownPeers' at
+    -- the time it's used). Subsequent uses of 'knownPeers' should include these
+    -- new endpoints.
+    , closeDiscovery :: m ()
+    }
+
+data DiscoveryError error = DiscoveryError error String
+    deriving (Show, Typeable, Generic)
+
+instance (Typeable error, Show error) => Exception (DiscoveryError error)

--- a/src/Network/Discovery/Transport/InMemory.hs
+++ b/src/Network/Discovery/Transport/InMemory.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Network.Discovery.Transport.InMemory (
+
+      inMemoryDiscovery
+    , InMemoryDiscoveryErrorCode
+
+    ) where
+
+import GHC.Generics (Generic)
+import Data.Typeable (Typeable)
+import Data.Set (Set)
+import qualified Data.Set as S
+import qualified Data.Map as M
+import Network.Discovery.Abstract
+import Network.Transport
+import Network.Transport.InMemory
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent.STM.TVar as TVar
+import Control.Monad.IO.Class (MonadIO, liftIO)
+
+-- | An InMemory network transport can be used as a NetworkDiscovery. It takes
+--   addresses from the transport's internal state.
+inMemoryDiscovery
+    :: ( MonadIO m )
+    => TransportInternals
+    -> m (NetworkDiscovery InMemoryDiscoveryErrorCode m)
+inMemoryDiscovery internals = do
+    peersTVar <- liftIO . TVar.newTVarIO $ S.empty
+    let knownPeers = liftIO . TVar.readTVarIO $ peersTVar
+    let discoverPeers = liftIO . STM.atomically $ do
+            mAllPeers <- getPeersFromInternals internals
+            case mAllPeers of
+                Nothing -> pure (Left (DiscoveryError InMemoryDiscoveryTransportClosed "Transport is closed"))
+                Just allPeers -> do
+                    knownPeers <- TVar.readTVar peersTVar
+                    let newPeers = allPeers `S.difference` knownPeers
+                    TVar.writeTVar peersTVar allPeers
+                    pure (Right newPeers)
+    -- No need to do anything on close, since we don't exactly use any
+    -- resources.
+    let close = pure ()
+    pure $ NetworkDiscovery knownPeers discoverPeers close
+
+getPeersFromInternals :: TransportInternals -> STM.STM (Maybe (Set EndPointAddress))
+getPeersFromInternals (TransportInternals tvar) = do
+    state <- TVar.readTVar tvar
+    case state of
+        TransportValid (ValidTransportState map _) ->
+            pure . Just $ S.fromList (M.keys map)
+        TransportClosed -> pure Nothing
+
+data InMemoryDiscoveryErrorCode = InMemoryDiscoveryTransportClosed
+  deriving (Show, Typeable, Generic)

--- a/src/Network/Discovery/Transport/Kademlia.hs
+++ b/src/Network/Discovery/Transport/Kademlia.hs
@@ -28,6 +28,8 @@ import Network.Transport
 import qualified Control.Concurrent.STM as STM
 import qualified Control.Concurrent.STM.TVar as TVar
 
+-- | Wrapper which provides a 'K.Serialize' instance for any type with a
+--   'Binary' instance.
 newtype KSerialize i = KSerialize i
     deriving (Eq, Ord, Show)
 
@@ -37,58 +39,56 @@ instance Binary i => K.Serialize (KSerialize i) where
         Right (unconsumed, _, i) -> Right (KSerialize i, BL.toStrict unconsumed)
     toBS (KSerialize i) = BL.toStrict . encode $ i
 
+-- | Configuration for a Kademlia node.
 data KademliaConfiguration i = KademliaConfiguration {
       kademliaPort :: Word16
+      -- ^ The port on which to run the server (it's UDP)
     , kademliaId :: i
+      -- ^ Some value to use as the identifier for this node. To use it, it must
+      --   have a 'Binary' instance. You may want to take a random value, and
+      --   it should serialize to something long enough for your expected
+      --   network size (every node in the network needs a unique id).
     }
 
 -- | Discovery peers using the Kademlia DHT. Nodes in this network will store
 --   their (assumed to be TCP transport) 'EndPointAddress'es and send them
 --   over the wire on request. NB there are two notions of ID here: the
 --   Kademlia IDs, and the 'EndPointAddress'es which are indexed by the former.
+--
+--   Many side-effects here: a Kademlia instance is created, grabbing a UDP
+--   socket and using it to talk to a peer, storing data in the DHT once it has
+--   been joined.
 kademliaDiscovery
     :: forall m i .
        ( MonadIO m, Binary i, Ord i )
     => KademliaConfiguration i
     -> K.Node i
     -- ^ A known peer, necessary in order to join the network.
+    --   If there are no other peers in the network, use this node's id.
     -> EndPointAddress
-    -- ^ My address. Will store it in the DHT.
+    -- ^ Local endpoint address. Will store it in the DHT.
     -> m (NetworkDiscovery KademliaDiscoveryErrorCode m)
 kademliaDiscovery configuration initialPeer myAddress = do
     let kid :: KSerialize i
         kid = KSerialize (kademliaId configuration)
     let port :: Int
         port = fromIntegral (kademliaPort configuration)
+    -- A Kademlia instance to do the DHT magic.
     kademliaInst :: K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
         <- liftIO $ K.create port kid
+    -- A TVar to cache the set of known peers at the last use of 'discoverPeers'
     peersTVar :: TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
         <- liftIO . TVar.newTVarIO $ M.empty
     let knownPeers = fmap (S.fromList . M.elems) . liftIO . TVar.readTVarIO $ peersTVar
     let discoverPeers = liftIO $ kademliaDiscoverPeers kademliaInst peersTVar
     let close = liftIO $ K.close kademliaInst
+    -- Join the network and store the local 'EndPointAddress'.
     liftIO $ kademliaJoinAndUpdate kademliaInst peersTVar initialPeer
     () <- liftIO $ K.store kademliaInst kid (KSerialize myAddress)
     pure $ NetworkDiscovery knownPeers discoverPeers close
 
-
-kademliaDiscoverPeers
-    :: forall i .
-       ( Binary i, Ord i )
-    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-    -> TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
-    -> IO (Either (DiscoveryError KademliaDiscoveryErrorCode) (S.Set EndPointAddress))
-kademliaDiscoverPeers kademliaInst peersTVar = do
-    recordedPeers <- TVar.readTVarIO peersTVar
-    currentPeers <- K.dumpPeers kademliaInst
-    -- The idea is to always update the TVar to the set of nodes in allPeers,
-    -- but only lookup the addresses for nodes which are not in the recorded
-    -- set to begin with.
-    currentWithAddresses <- fmap (M.mapMaybe id) (kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers)
-    STM.atomically $ TVar.writeTVar peersTVar currentWithAddresses
-    let new = currentWithAddresses `M.difference` recordedPeers
-    pure $ Right (S.fromList (M.elems new))
-
+-- | Join a Kademlia network (using a given known node address) and update the
+--   known peers cache.
 kademliaJoinAndUpdate
     :: forall i .
        ( Binary i, Ord i )
@@ -114,6 +114,29 @@ kademliaJoinAndUpdate kademliaInst peersTVar initialPeer = do
     initialPeer' = case initialPeer of
         K.Node peer id -> K.Node peer (KSerialize id)
 
+-- | Update the known peers cache.
+--
+--   FIXME: error reporting. Should perhaps give a list of all of the errors
+--   which occurred.
+kademliaDiscoverPeers
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+    -> IO (Either (DiscoveryError KademliaDiscoveryErrorCode) (S.Set EndPointAddress))
+kademliaDiscoverPeers kademliaInst peersTVar = do
+    recordedPeers <- TVar.readTVarIO peersTVar
+    currentPeers <- K.dumpPeers kademliaInst
+    -- The idea is to always update the TVar to the set of nodes in allPeers,
+    -- but only lookup the addresses for nodes which are not in the recorded
+    -- set to begin with.
+    currentWithAddresses <- fmap (M.mapMaybe id) (kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers)
+    STM.atomically $ TVar.writeTVar peersTVar currentWithAddresses
+    let new = currentWithAddresses `M.difference` recordedPeers
+    pure $ Right (S.fromList (M.elems new))
+
+-- | Look up the 'EndPointAddress's for a set of nodes.
+--   See 'kademliaLookupEndPointAddress'
 kademliaLookupEndPointAddresses
     :: forall i .
        ( Binary i, Ord i )
@@ -131,11 +154,19 @@ kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers = do
   isJust (Just _) = True
   isJust _ = False
 
+-- | Look up the 'EndPointAddress' for a given node. The host and port of
+--   the node are known, along with its Kademlia identifier, but the
+--   'EndPointAddress' cannot be inferred from these things. The DHT stores
+--   that 'EndPointAddress' using the node's Kademlia identifier as key, so
+--   we look that up in the table. Nodes for which the 'EndPointAddress' is
+--   already known are not looked up.
 kademliaLookupEndPointAddress
     :: forall i .
        ( Binary i, Ord i )
     => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
     -> M.Map (K.Node (KSerialize i)) EndPointAddress
+    -- ^ The current set of recorded peers. We don't lookup an 'EndPointAddress'
+    --   for any of these, we just use the one in the map.
     -> K.Node (KSerialize i)
     -> IO (Maybe EndPointAddress)
 kademliaLookupEndPointAddress kademliaInst recordedPeers peer@(K.Node _ id) =

--- a/src/Network/Discovery/Transport/Kademlia.hs
+++ b/src/Network/Discovery/Transport/Kademlia.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Network.Discovery.Transport.Kademlia (
+
+      K.Node(..)
+    , K.Peer(..)
+    , KademliaConfiguration(..)
+    , kademliaDiscovery
+    , KademliaDiscoveryErrorCode(..)
+
+    ) where
+
+import GHC.Generics (Generic)
+import Control.Monad (forM)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Typeable (Typeable)
+import Data.Set (Set)
+import qualified Data.Set as S
+import qualified Data.Map.Strict as M
+import qualified Data.ByteString.Lazy as BL
+import Data.Word (Word16)
+import Data.Binary (encode, decodeOrFail, Binary)
+import Network.Discovery.Abstract
+import qualified Network.Kademlia as K
+import Network.Transport
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent.STM.TVar as TVar
+
+newtype KSerialize i = KSerialize i
+    deriving (Eq, Ord, Show)
+
+instance Binary i => K.Serialize (KSerialize i) where
+    fromBS bs = case decodeOrFail (BL.fromStrict bs) of
+        Left (_, _, str) -> Left str
+        Right (unconsumed, _, i) -> Right (KSerialize i, BL.toStrict unconsumed)
+    toBS (KSerialize i) = BL.toStrict . encode $ i
+
+data KademliaConfiguration i = KademliaConfiguration {
+      kademliaPort :: Word16
+    , kademliaId :: i
+    }
+
+-- | Discovery peers using the Kademlia DHT. Nodes in this network will store
+--   their (assumed to be TCP transport) 'EndPointAddress'es and send them
+--   over the wire on request. NB there are two notions of ID here: the
+--   Kademlia IDs, and the 'EndPointAddress'es which are indexed by the former.
+kademliaDiscovery
+    :: forall m i .
+       ( MonadIO m, Binary i, Ord i )
+    => KademliaConfiguration i
+    -> K.Node i
+    -- ^ A known peer, necessary in order to join the network.
+    -> EndPointAddress
+    -- ^ My address. Will store it in the DHT.
+    -> m (NetworkDiscovery KademliaDiscoveryErrorCode m)
+kademliaDiscovery configuration initialPeer myAddress = do
+    let kid :: KSerialize i
+        kid = KSerialize (kademliaId configuration)
+    let port :: Int
+        port = fromIntegral (kademliaPort configuration)
+    kademliaInst :: K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+        <- liftIO $ K.create port kid
+    peersTVar :: TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+        <- liftIO . TVar.newTVarIO $ M.empty
+    let knownPeers = fmap (S.fromList . M.elems) . liftIO . TVar.readTVarIO $ peersTVar
+    let discoverPeers = liftIO $ kademliaDiscoverPeers kademliaInst peersTVar
+    let close = liftIO $ K.close kademliaInst
+    liftIO $ kademliaJoinAndUpdate kademliaInst peersTVar initialPeer
+    () <- liftIO $ K.store kademliaInst kid (KSerialize myAddress)
+    pure $ NetworkDiscovery knownPeers discoverPeers close
+
+
+kademliaDiscoverPeers
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+    -> IO (Either (DiscoveryError KademliaDiscoveryErrorCode) (S.Set EndPointAddress))
+kademliaDiscoverPeers kademliaInst peersTVar = do
+    recordedPeers <- TVar.readTVarIO peersTVar
+    currentPeers <- K.dumpPeers kademliaInst
+    -- The idea is to always update the TVar to the set of nodes in allPeers,
+    -- but only lookup the addresses for nodes which are not in the recorded
+    -- set to begin with.
+    currentWithAddresses <- fmap (M.mapMaybe id) (kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers)
+    STM.atomically $ TVar.writeTVar peersTVar currentWithAddresses
+    let new = currentWithAddresses `M.difference` recordedPeers
+    pure $ Right (S.fromList (M.elems new))
+
+kademliaJoinAndUpdate
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+    -> K.Node i
+    -> IO (Either (DiscoveryError KademliaDiscoveryErrorCode) (S.Set EndPointAddress))
+kademliaJoinAndUpdate kademliaInst peersTVar initialPeer = do
+    result <- K.joinNetwork kademliaInst initialPeer'
+    case result of
+        K.IDClash -> pure $ Left (DiscoveryError KademliaIdClash "ID clash in network")
+        K.NodeDown -> pure $ Left (DiscoveryError KademliaInitialPeerDown "Initial peer is down")
+        -- [sic]
+        K.JoinSucces -> do
+            peerList <- K.dumpPeers kademliaInst
+            -- We have the peers, but we do not have the 'EndPointAddress'es for
+            -- them. We must ask the network for them.
+            endPointAddresses <- fmap (M.mapMaybe id) (kademliaLookupEndPointAddresses kademliaInst M.empty peerList)
+            STM.atomically $ TVar.writeTVar peersTVar endPointAddresses
+            pure $ Right (S.fromList (M.elems endPointAddresses))
+    where
+    initialPeer' :: K.Node (KSerialize i)
+    initialPeer' = case initialPeer of
+        K.Node peer id -> K.Node peer (KSerialize id)
+
+kademliaLookupEndPointAddresses
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> M.Map (K.Node (KSerialize i)) EndPointAddress
+    -> [K.Node (KSerialize i)]
+    -> IO (M.Map (K.Node (KSerialize i)) (Maybe EndPointAddress))
+kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers = do
+    -- TODO do this in parallel, as each one may induce a blocking lookup.
+    endPointAddresses <- forM currentPeers (kademliaLookupEndPointAddress kademliaInst recordedPeers)
+    let assoc :: [(K.Node (KSerialize i), Maybe EndPointAddress)]
+        assoc = zip currentPeers endPointAddresses
+    pure $ M.fromList assoc
+  where
+  isJust (Just _) = True
+  isJust _ = False
+
+kademliaLookupEndPointAddress
+    :: forall i .
+       ( Binary i, Ord i )
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
+    -> M.Map (K.Node (KSerialize i)) EndPointAddress
+    -> K.Node (KSerialize i)
+    -> IO (Maybe EndPointAddress)
+kademliaLookupEndPointAddress kademliaInst recordedPeers peer@(K.Node _ id) =
+    case M.lookup peer recordedPeers of
+        Nothing -> do
+            outcome <- K.lookup kademliaInst id
+            pure $ case outcome of
+                Nothing -> Nothing
+                Just (KSerialize endPointAddress, _) -> Just endPointAddress
+        Just address -> pure (Just address)
+
+data KademliaDiscoveryErrorCode
+    = KademliaIdClash
+    | KademliaInitialPeerDown
+    deriving (Show, Typeable, Generic)

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -32,6 +32,7 @@ import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Builder.Extra as BS
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
+import Data.Proxy (Proxy(..))
 import qualified Network.Transport.Abstract as NT
 import System.Random (StdGen)
 import Mockable.Class
@@ -40,6 +41,8 @@ import Mockable.Channel
 import Mockable.SharedAtomic
 import Mockable.Exception
 import GHC.Generics (Generic)
+
+import qualified Debug.Trace as Debug
 
 data Node (m :: * -> *) = Node {
        nodeLL      :: LL.Node m,
@@ -73,26 +76,30 @@ data ListenerAction m where
 
   -- | A listener that handles an incoming bi-directional conversation.
   ListenerActionConversation
-    :: (LL.NodeId -> ConversationActions m -> m ())
+    :: ( Binary snd, Binary rcv )
+    => (LL.NodeId -> ConversationActions snd rcv m -> m ())
     -> ListenerAction m
 
 data SendActions m = SendActions {
        -- | Send a isolated (sessionless) message to a node
        sendTo :: forall body. Binary body => LL.NodeId -> MessageName -> body -> m (),
 
-       -- | Establish a bi-direction conversation session with a node
-       connect :: LL.NodeId -> m (ConversationActions m)
+       -- | Establish a bi-direction conversation session with a node.
+       withConnectionTo
+           :: forall snd rcv.
+              ( Binary snd, Binary rcv )
+           => LL.NodeId
+           -> MessageName
+           -> (ConversationActions snd rcv m -> m ())
+           -> m ()
      }
 
-data ConversationActions m = ConversationActions {
+data ConversationActions snd rcv m = ConversationActions {
        -- | Send a message within the context of this conversation
-       send  :: forall msg. Binary msg => msg -> m (),
+       send  :: snd -> m (),
 
        -- | Receive a message within the context of this conversation
-       recv  :: forall msg. Binary msg => m msg,
-
-       -- | Close the outbound side of this conversation
-       close :: m ()  -- TODO: needed? if so only for early close. Should by automatic.
+       recv  :: m rcv
      }
 
 type ListenerIndex m = Map MessageName (ListenerAction m)
@@ -116,11 +123,35 @@ startNode
     -> [Listener m]
     -> m (Node m)
 startNode transport prng workers listeners = do
-    rec { node <- LL.startNode transport prng (handlerIn node sendAction) (handlerInOut node)
-        ; let sendAction = SendActions { sendTo = sendMsg node, connect = undefined }
+    rec { node <- LL.startNode transport prng (handlerIn node sendActions) (handlerInOut node)
+
+        -- The sendActions, to be given to the workers, so that they can send
+        -- unidirectional messages and also establish bidirectional
+        -- conversations.
+        ; let sendActions :: SendActions m
+              sendActions = SendActions {
+                    -- LL.withOutChannel safely establishes a connection for
+                    -- us, and closes it when we're done.
+                    sendTo = \nodeId msgName body -> LL.withOutChannel node nodeId $ \channelOut ->
+                        LL.writeChannel channelOut (LBS.toChunks (serialiseMsg msgName body))
+                    -- LL.withInOutChannel safely establishes a bidirectional
+                    -- connection, and closes it when we're done.
+                  , withConnectionTo = \nodeId msgName f -> LL.withInOutChannel node nodeId $ \inchan channelOut -> do
+                        let cactions = ConversationActions {
+                                  send = \body -> LL.writeChannel channelOut (LBS.toChunks (serialiseBody body))
+                                , recv = do
+                                      next <- recvNext inchan
+                                      case next of
+                                          End -> error "End of peer's conversation response"
+                                          NoParse -> error "Failed to parse peer's conversation response"
+                                          Input msg -> pure msg
+                                }
+                        LL.writeChannel channelOut (LBS.toChunks (serialiseMsgName msgName))
+                        f cactions
+                  }
         }
     tids <- sequence
-              [ fork $ worker sendAction
+              [ fork $ worker sendActions
               | worker <- workers ]
     return Node {
       nodeLL      = node,
@@ -131,49 +162,64 @@ startNode transport prng workers listeners = do
     listenerIndex :: ListenerIndex m
     (listenerIndex, conflictingNames) = makeListenerIndex listeners
 
+    -- Handle incoming data from unidirectional connections: try to read the
+    -- message name, use it to determine a listener, parse the body, then
+    -- run the listener.
     handlerIn :: LL.Node m -> SendActions m -> LL.NodeId -> ChannelIn m -> m ()
-    handlerIn node sendActions peerId (ChannelIn chan) = do
-        (msgName :: MessageName, rest) <- recvPart chan (fromString "")
-        let listener = M.lookup msgName listenerIndex
-        case listener of
-            Just (ListenerActionOneMsg action) -> do
-                (msgBody, rest') <- recvPart chan rest
-                tid <- fork (action peerId sendActions msgBody)
-                -- TODO remember the thread id? Inform dispatcher when it's
-                -- finished?
-                pure ()
-            -- If it's a conversation listener, then that's an error, no?
-            Just (ListenerActionConversation _) -> error ("Wrong listener type! " ++ show msgName)
-            Nothing -> error ("No listener! " ++ show msgName)
-        pure ()
+    handlerIn node sendActions peerId inchan = do
+        (input :: Input MessageName) <- recvNext inchan
+        case input of
+            End -> error "handerIn : unexpected end of input"
+            -- TBD recurse and continue handling even after a no parse?
+            NoParse -> error "handlerIn : failed to parse message name"
+            Input msgName -> do
+                let listener = M.lookup msgName listenerIndex
+                case listener of
+                    Just (ListenerActionOneMsg action) -> do
+                        input' <- recvNext inchan
+                        case input' of
+                            End -> error "handerIn : unexpected end of input"
+                            NoParse -> error "handlerIn : failed to parse message body"
+                            Input msgBody -> do
+                                -- What if more data comes in after this point?
+                                -- Does it matter? It'll be discarded eventually,
+                                -- but if the peer keeps piling on data and our
+                                -- action is relatively long-running, all that
+                                -- useless data will be retained for a while.
+                                --
+                                -- Do we need a way for the handlers (like
+                                -- handlerIn) to signal that they don't expect
+                                -- any more input?
+                                action peerId sendActions msgBody
+                    -- If it's a conversation listener, then that's an error, no?
+                    Just (ListenerActionConversation _) -> error ("handlerIn : wrong listener type. Expected unidirectional for " ++ show msgName)
+                    Nothing -> error ("handlerIn : no listener for " ++ show msgName)
 
+    -- Handle incoming data from a bidirectional connection: try to read the
+    -- message name, then choose a listener and fork a thread to run it.
     handlerInOut :: LL.Node m -> LL.NodeId -> ChannelIn m -> ChannelOut m -> m ()
-    handlerInOut node peerId (ChannelIn inchan) (ChannelOut outchan) = do
-        (msgName :: MessageName, rest) <- recvPart inchan (fromString "")
-        let listener = M.lookup msgName listenerIndex
-        case listener of
-            Just (ListenerActionConversation action) -> do
-                -- NB we do not pull the body from the channel.
-                -- It's up to the listener to do so.
-                -- We also need a channel which will accept messages without
-                -- names.
-                let csend :: Binary body => body -> m ()
-                    -- Write to the outchan.
-                    csend = undefined
-                let crecv :: Binary body => m body
-                    -- Read from the inchan.
-                    crecv = undefined
-                let cclose :: m ()
-                    -- I dunno.
-                    cclose = undefined
-                let conversationActions = ConversationActions csend crecv cclose
-                tid <- fork (action peerId conversationActions)
-                pure ()
-            Just (ListenerActionOneMsg _) -> error ("Wrong listener type! " ++ show msgName)
-            Nothing -> error ("No listener! " ++ show msgName)
-        pure ()
-
-    --TODO: fill in the dispatcher impl:
+    handlerInOut node peerId inchan outchan = do
+        (input :: Input MessageName) <- recvNext inchan
+        case input of
+            End -> error "handlerInOut : unexpected end of input"
+            NoParse -> error "handlerInOut : failed to parse message name"
+            Input msgName -> do
+                let listener = M.lookup msgName listenerIndex
+                case listener of
+                    Just (ListenerActionConversation action) ->
+                        let cactions = ConversationActions {
+                                  send = \body -> do
+                                      LL.writeChannel outchan (LBS.toChunks (serialiseBody body))
+                                , recv = do
+                                      next <- recvNext inchan
+                                      case next of
+                                          End -> error "End of peer's conversation input"
+                                          NoParse -> error "Failed to parse peer's conversation input"
+                                          Input msg -> pure msg
+                                }
+                        in  action peerId cactions
+                    Just (ListenerActionOneMsg _) -> error ("handlerInOut : wrong listener type. Expected bidirectional for " ++ show msgName)
+                    Nothing -> error ("handlerInOut : no listener for " ++ show msgName)
 
 stopNode :: ( Mockable Fork m ) => Node m -> m ()
 stopNode Node {..} = do
@@ -183,6 +229,7 @@ stopNode Node {..} = do
     -- alternatively we could try stopping new incoming messages
     -- and wait for all handlers to finish
 
+-- | Send a message (name and body).
 sendMsg
     :: ( Monad m, Binary body )
     => LL.Node m
@@ -192,6 +239,33 @@ sendMsg
     -> m ()
 sendMsg node nodeid name body =
     LL.sendMsg node nodeid (serialiseMsg name body)
+
+-- | Send a body (message without a name).
+sendBody
+    :: ( Monad m, Binary body )
+    => LL.Node m
+    -> LL.NodeId
+    -> body
+    -> m ()
+sendBody node nodeid body =
+    LL.sendMsg node nodeid (serialiseBody body)
+
+serialiseMsgName
+    :: MessageName
+    -> LBS.ByteString
+serialiseMsgName =
+    BS.toLazyByteStringWith (BS.untrimmedStrategy 256 4096) LBS.empty
+    . Bin.execPut
+    . put
+
+serialiseBody
+    :: ( Binary body )
+    => body
+    -> LBS.ByteString
+serialiseBody =
+    BS.toLazyByteStringWith (BS.untrimmedStrategy 256 4096) LBS.empty
+    . Bin.execPut
+    . put
 
 serialiseMsg :: Binary body => MessageName -> body -> LBS.ByteString
 serialiseMsg name body =
@@ -204,34 +278,50 @@ serialiseMsg name body =
                  LBS.empty
               . Bin.execPut
 
-sendBody
-    :: ( Monad m, Binary body )
-    => LL.Node m
-    -> LL.NodeId
-    -> body
-    -> m ()
-sendBody node nodeid body =
-    LL.sendMsg node nodeid (serialiseBody body)
 
-serialiseBody
-    :: ( Binary body )
-    => body
-    -> LBS.ByteString
-serialiseBody =
-    BS.toLazyByteStringWith (BS.untrimmedStrategy 256 4096) LBS.empty
-    . Bin.execPut
-    . put
+data Input t where
+    End :: Input t
+    NoParse :: Input t
+    Input :: t -> Input t
+
+-- | Receive input from a ChannelIn.
+--   If the channel's first element is 'Nothing' then it's the end of
+--   input and you'll get 'End', otherwise we try to parse the 'thing'.
+--   Unconsumed input is pushed back into the channel so that subsequent
+--   'recvNext's will use it.
+recvNext
+    :: ( Mockable Channel m, Binary thing )
+    => ChannelIn m
+    -> m (Input thing)
+recvNext (ChannelIn chan) = do
+    mx <- readChannel chan
+    case mx of
+        Nothing -> pure End
+        Just bs -> do
+            (part, trailing) <- recvPart chan bs
+            unGetChannel chan (Just trailing)
+            case part of
+                Nothing -> pure NoParse
+                Just t -> pure (Input t)
+
+-- FIXME
+-- Serializing to "" is a problem. (), for instance, can't be used as data
+-- over the wire.
+-- It serializes to "". If we demand that the "" appear as a separate piece
+-- of the channel then we're fine with the current implementation of recvNext.
+-- If not, then even if a Nothing is pulled from the channel, we may still
+-- parse a ().
 
 recvPart
     :: ( Mockable Channel m, Binary thing )
     => ChannelT m (Maybe BS.ByteString)    -- source
     -> BS.ByteString                       -- prefix
-    -> m (thing, BS.ByteString)            -- trailing
+    -> m (Maybe thing, BS.ByteString)      -- trailing
 recvPart chan prefix =
     go (Bin.pushChunk (Bin.runGetIncremental Bin.get) prefix)
   where
-    go (Bin.Done trailing _ a) = return (a, trailing)
-    go (Bin.Fail _trailing _ err) = fail "TODO"
+    go (Bin.Done trailing _ a) = return (Just a, trailing)
+    go (Bin.Fail trailing _ err) = return (Nothing, trailing)
     go (Bin.Partial continue) = do
       mx <- readChannel chan
       go (continue mx)

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -229,27 +229,6 @@ stopNode Node {..} = do
     -- alternatively we could try stopping new incoming messages
     -- and wait for all handlers to finish
 
--- | Send a message (name and body).
-sendMsg
-    :: ( Monad m, Binary body )
-    => LL.Node m
-    -> LL.NodeId
-    -> MessageName
-    -> body
-    -> m ()
-sendMsg node nodeid name body =
-    LL.sendMsg node nodeid (serialiseMsg name body)
-
--- | Send a body (message without a name).
-sendBody
-    :: ( Monad m, Binary body )
-    => LL.Node m
-    -> LL.NodeId
-    -> body
-    -> m ()
-sendBody node nodeid body =
-    LL.sendMsg node nodeid (serialiseBody body)
-
 serialiseMsgName
     :: MessageName
     -> LBS.ByteString

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -108,7 +108,8 @@ makeListenerIndex = foldr combine (M.empty, [])
 startNode
     :: forall m .
        ( Mockable Fork m, Mockable Throw m, Mockable Channel m
-       , Mockable SharedAtomic m, Mockable Bracket m, MonadFix m )
+       , Mockable SharedAtomic m, Mockable Bracket m, Mockable Catch m
+       , MonadFix m )
     => NT.Transport m
     -> StdGen
     -> [Worker m]

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -17,7 +17,6 @@ module Node.Internal (
     ChannelIn(..),
     ChannelOut(..),
     connectOutChannel,
-    connectInOutChannel,
     closeChannel,
     withOutChannel,
     withInOutChannel,
@@ -25,6 +24,7 @@ module Node.Internal (
     readChannel,
   ) where
 
+import Data.String (fromString)
 import Data.Binary     as Bin
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString      as BS
@@ -35,7 +35,7 @@ import qualified Data.Map.Strict as Map
 import Data.Monoid
 import Data.Typeable
 import Data.List (foldl')
-import Control.Exception hiding (bracket, throw, catch)
+import Control.Exception hiding (bracket, throw, catch, finally)
 import qualified Network.Transport.Abstract as NT
 import qualified Network.Transport as NT (EventErrorCode(EventConnectionLost, EventEndPointFailed, EventTransportFailed))
 import System.Random (StdGen, random)
@@ -45,15 +45,20 @@ import Mockable.Exception
 import qualified Mockable.Channel as Channel
 import Mockable.SharedAtomic
 
-
 -- A node id wraps a network-transport endpoint address
 newtype NodeId = NodeId NT.EndPointAddress
   deriving (Eq, Ord, Show)
 
+type NodeState m =
+    ( StdGen
+    , Map Nonce (NonceState m)
+    , [(Either NT.ConnectionId Nonce, Maybe SomeException)]
+    )
+
 data Node (m :: * -> *) = Node {
        nodeEndPoint         :: NT.EndPoint m,
        nodeDispatcherThread :: ThreadId m,
-       nodeExpectedIncoming :: SharedAtomicT m (StdGen, Map Nonce (ThreadId m, ChannelIn m))
+       nodeState :: SharedAtomicT m (NodeState m)
      }
 
 type Nonce = Word64
@@ -65,8 +70,10 @@ data NodeException =
 
 instance Exception NodeException
 
+-- | Input from the wire. Nothing means there's no more to come.
 newtype ChannelIn m = ChannelIn (Channel.ChannelT m (Maybe BS.ByteString))
 
+-- | Output to the wire.
 newtype ChannelOut m = ChannelOut (NT.Connection m)
 
 startNode :: ( Mockable SharedAtomic m, Mockable Fork m, Mockable Bracket m
@@ -77,15 +84,15 @@ startNode :: ( Mockable SharedAtomic m, Mockable Fork m, Mockable Bracket m
           -> (NodeId -> ChannelIn m -> ChannelOut m -> m ())
           -> m (Node m)
 startNode transport prng handlerIn handlerOut = do
-    Right endpoint <- NT.newEndPoint transport --TODO: error handling
-    incomingVar    <- newSharedAtomic (prng, Map.empty)
-    finishedVar    <- newSharedAtomic []
-    tid  <- fork (nodeDispatcher endpoint incomingVar finishedVar handlerIn handlerOut)
+    Right endpoint       <- NT.newEndPoint transport --TODO: error handling
+    sharedState          <- newSharedAtomic (prng, Map.empty, [])
+    tid                  <- fork $
+        nodeDispatcher endpoint sharedState handlerIn handlerOut
     --TODO: exceptions in the forkIO
     return Node {
       nodeEndPoint         = endpoint,
       nodeDispatcherThread = tid,
-      nodeExpectedIncoming = incomingVar
+      nodeState = sharedState
     }
 
 
@@ -97,35 +104,62 @@ stopNode Node {..} =
     -- It'll also close all TCP connections.
 
 
+-- | State which is local to the dispatcher, and need not be accessible to
+--   any other thread.
 type DispatcherState m = Map NT.ConnectionId (ConnectionState m)
+
 data ConnectionState m =
 
-       -- We got a new connection and are waiting on the first chunk of data
-       ConnectionNew !NodeId
+       -- | We got a new connection and are waiting on the first chunk of data
+      ConnectionNew !NodeId
 
-       -- We got the first chunk of data, we're now waiting either for more
-       -- data or for the connection to be closed. This supports the small
-       -- message optimisation.
-     | ConnectionNewChunks !NodeId ![BS.ByteString]
+      -- | We got the first chunk of data, we're now waiting either for more
+      --   data or for the connection to be closed. This supports the small
+      --   message optimisation.
+    | ConnectionNewChunks !NodeId ![BS.ByteString]
 
-       -- We've forked a thread to handle the message. The connection is still
-       -- open and data is still arriving. We have a channel to pass the
-       -- incoming chunks off to the other thread.
-     | ConnectionReceiving !(ThreadId m) !(Channel.ChannelT m (Maybe BS.ByteString))
+      -- | We've forked a thread to handle the message. The connection is still
+      --   open and data is still arriving. We have a channel to pass the
+      --   incoming chunks off to the other thread.
+    | ConnectionReceiving !(ThreadId m) !(Channel.ChannelT m (Maybe BS.ByteString))
 
-       -- We've forked a thread to handle the message. The connection is now
-       -- closed and we have all the data already, but the thread we forked
-       -- to handle it is still active.
-     | ConnectionClosed !(ThreadId m)
+      -- | We've forked a thread to handle the message. The connection is now
+      --   closed and we have all the data already, but the thread we forked
+      --   to handle it is still active.
+    | ConnectionClosed !(ThreadId m)
+
+      -- | The handler which we forked to process the data has finished.
+      --   Subsequent incoming data has nowhere to go.
+    | ConnectionHandlerFinished !(Maybe SomeException)
+
+-- | Bidirectional connections (conversations) are identified not by
+--   ConnectionId but by a nonce, because their handlers run before any
+--   connection is established.
+--
+--   Once a connection for a conversation is established, its nonce is
+--   associated with it via 'NonceHandlerConnected', but prior to this it's
+--   'NonceHandlerNotConnected', meaning the handler is running but a
+--   SYN/ACK handshake has not been completed.
+--
+--   The NonceState must be accessible by the dispatcher and by other threads,
+--   because other threads may initiate a conversation.
+data NonceState m =
+
+      NonceHandlerNotConnected !(ThreadId m) !(ChannelIn m)
+
+    | NonceHandlerConnected !NT.ConnectionId
+
+instance Show (ConnectionState m) where
+    show term = case term of
+        ConnectionNew nodeid -> "ConnectionNew " ++ show nodeid
+        ConnectionNewChunks nodeid chunks -> "ConnectionNewChunks " ++ show nodeid
+        ConnectionReceiving _ _ -> "ConnectionReceiving"
+        ConnectionClosed _ -> "ConnectionClosed"
+        ConnectionHandlerFinished e -> "ConnectionHandlerFinished " ++ show e
 
 --TODO: extend this to keep track of the number of active threads and total
 -- amount of in flight incoming data. This will be needed to inform the
 -- back-pressure policy.
-
---TODO: need to fill in how threads are cleaned up. The 'finally' handler for
--- the forked thread will post a cleanup event to the dispatcher thread which
--- will eventually get it and remove the ConnectionId from the DispatcherState
--- and update any stats (ie decrement counts of resources in use)
 
 -- | The one thread that handles /all/ incoming messages and dispatches them
 -- to various handlers.
@@ -135,172 +169,287 @@ nodeDispatcher :: forall m .
                   , Mockable Channel.Channel m, Mockable Throw m
                   , Mockable Catch m )
                => NT.EndPoint m
-               -> SharedAtomicT m (StdGen, Map Nonce (ThreadId m, ChannelIn m))
-               -> SharedAtomicT m ([(NT.ConnectionId, Maybe SomeException)])
+               -> SharedAtomicT m (NodeState m)
+               -- ^ Nonce states and a StdGen to generate nonces. It's in a
+               --   shared atomic because other threads must be able to alter
+               --   it when they start a conversation.
+               --   The third element of the triple will be updated by handler
+               --   threads when they finish.
                -> (NodeId -> ChannelIn m -> m ())
                -> (NodeId -> ChannelIn m -> ChannelOut m -> m ())
                -> m ()
-nodeDispatcher endpoint incomingVar finished handlerIn handlerInOut =
+nodeDispatcher endpoint nodeState handlerIn handlerInOut =
     loop Map.empty
   where
+
+    nodeid = NodeId $ NT.address endpoint
+
+    finally :: m t -> m () -> m t
+    finally action after = bracket (pure ()) (const after) (const action)
 
     -- | Signal that a thread handling a given ConnectionId is finished.
     --   It's very important that this is run to completion for every spawned
     --   thread, else the DispatcherState will never forget the entry for
     --   this ConnectionId.
-    --
-    --   FIXME must be sure that this is uninterruptible. That depends upon the
-    --   semantics of the chosen SharedAtomic! If an MVar is used then it
-    --   should be OK; docs in Control.Exception say that a takeMVar is
-    --   uninterruptible if the MVar is full, putMVar uninterruptible if the
-    --   MVar is empty, so a modifyMVar should be uninterruptible.
-    signalFinished :: (NT.ConnectionId, Maybe SomeException) -> m ()
-    signalFinished outcome = modifySharedAtomic finished (\lst -> pure (outcome : lst, ()))
+    signalFinished :: (Either NT.ConnectionId Nonce, Maybe SomeException) -> m ()
+    signalFinished outcome = modifySharedAtomic nodeState $ \(prng, nonces, finished) ->
+            pure ((prng, nonces, outcome : finished), ())
 
     -- | Augment some m term so that it always reports its ConnectionId when
     --   finished, along with the exception if one was raised. We catch all
-    --   exceptions but it's rethrown.
-    reportConnidAndException :: NT.ConnectionId -> m () -> m ()
-    reportConnidAndException connid action = normal `catch` exceptional
+    --   exceptions in order to do this, but they are re-thrown.
+    --
+    --   The motif is also used in withInOutChannel, the only other place where
+    --   a connection handler is created and tracked.
+    finishHandler :: Either NT.ConnectionId Nonce -> m () -> m ()
+    finishHandler connidOrNonce action = normal `catch` exceptional
         where
         normal :: m ()
         normal = do
             _ <- action
-            signalFinished (connid, Nothing)
+            signalFinished (connidOrNonce, Nothing)
         exceptional :: SomeException -> m ()
         exceptional e = do
-            signalFinished (connid, Just e)
+            signalFinished (connidOrNonce, Just e)
             throw e
 
     -- Take the dead threads from the shared atomic and release them all from
-    -- the map.
+    -- the map if their connection is also closed.
+    -- Only if the connection is closed *and* the handler is finished, can we
+    -- forget about a connection id. It could be that the handler is finished,
+    -- but we receive more data, in which case we want to somehow make the
+    -- peer stop pushing any data.
+    -- If the connection is closed after the handler finishes, then the entry
+    -- in the state map will be cleared by the dispatcher loop.
+    --
     -- TBD use the reported exceptions to inform the dispatcher somehow?
     -- If a lot of threads are giving exceptions, should we change dispatcher
     -- behavior?
-    clearDeadThreads :: DispatcherState m -> m (DispatcherState m)
-    clearDeadThreads state = do
-        finished <- modifySharedAtomic finished (\lst -> pure ([], lst))
-        pure $ foldl' (\state (connid, _) -> Map.delete connid state) state finished
+    updateStateForFinishedHandlers :: DispatcherState m -> m (DispatcherState m)
+    updateStateForFinishedHandlers state = modifySharedAtomic nodeState $ \(prng, nonces, finished) -> do
+        -- For every Left (c :: NT.ConnectionId) we can remove it from the map
+        -- if its connection is closed, or indicate that the handler is finished
+        -- so that it will be removed when the connection is closed.
+        --
+        -- For every Right (n :: Nonce) we act depending on the nonce state.
+        -- If the handler isn't connected, we'll just drop the nonce state
+        -- entry.
+        -- If the handler is connected, we'll update the connection state for
+        -- that ConnectionId to say the handler has finished.
+        let (state', nonces') = foldl' folder (state, nonces) finished
+        --() <- trace ("DEBUG: state map size is " ++ show (Map.size state')) (pure ())
+        --() <- trace ("DEBUG: nonce map size is " ++ show (Map.size nonces')) (pure ())
+        pure ((prng, nonces', []), state')
+        where
+
+        -- Updates connection and nonce states in a left fold.
+        folder (connIdState, nonces) (connidOrNonce, e) = case connidOrNonce of
+            Left connid -> (Map.update (connUpdater e) connid connIdState, nonces)
+            Right nonce -> folderNonce (connIdState, nonces) (nonce, e)
+
+        folderConn (connIdState, nonces) (connid, e) =
+            (Map.update (connUpdater e) connid connIdState, nonces)
+
+        folderNonce (connIdState, nonces) (nonce, e) = case Map.lookup nonce nonces of
+            Nothing -> error "Handler for unknown nonce finished"
+            Just (NonceHandlerNotConnected _ _) ->
+                (connIdState, Map.delete nonce nonces)
+            Just (NonceHandlerConnected connid) ->
+                ( Map.update (connUpdater e) connid connIdState
+                , Map.delete nonce nonces
+                )
+
+        connUpdater :: Maybe SomeException -> ConnectionState m -> Maybe (ConnectionState m)
+        connUpdater e connState = case connState of
+            ConnectionClosed _ -> Nothing
+            _ -> Just (ConnectionHandlerFinished e)
+
+    -- Handle the first chunks received, interpreting the control byte(s).
+    handleFirstChunks
+        :: NT.ConnectionId
+        -> NodeId
+        -> [BS.ByteString]
+        -> DispatcherState m
+        -> m (Maybe (ConnectionState m))
+    handleFirstChunks connid peer@(NodeId peerEndpointAddr) chunks !state =
+        case LBS.uncons (LBS.fromChunks chunks) of
+            -- Empty. Wait for more data.
+            Nothing -> pure Nothing
+            Just (w, ws)
+                -- Peer wants a unidirectional (peer -> local)
+                -- connection. Make a channel for the incoming
+                -- data and fork a thread to consume it.
+                | w == controlHeaderCodeUnidirectional -> do
+                  chan <- Channel.newChannel
+                  mapM_ (Channel.writeChannel chan . Just) (LBS.toChunks ws)
+                  tid  <- fork $ finishHandler (Left connid) (handlerIn peer (ChannelIn chan))
+                  pure . Just $ ConnectionReceiving tid chan
+
+                -- Bidirectional header without the nonce
+                -- attached. Wait for the nonce.
+                | w == controlHeaderCodeBidirectionalAck ||
+                  w == controlHeaderCodeBidirectionalSyn
+                , LBS.length ws < 8 -> -- need more data
+                  pure . Just $ ConnectionNewChunks peer chunks
+
+                -- Peer wants a bidirectional connection.
+                -- Fork a thread to reply with an ACK and then
+                -- handle according to handlerInOut.
+                | w == controlHeaderCodeBidirectionalSyn
+                , Right (ws',_,nonce) <- decodeOrFail ws -> do
+                  chan <- Channel.newChannel
+                  mapM_ (Channel.writeChannel chan . Just) (LBS.toChunks ws')
+                  let action = do
+                          mconn <- NT.connect
+                                     endpoint
+                                     peerEndpointAddr
+                                     NT.ReliableOrdered
+                                     NT.ConnectHints{ connectTimeout = Nothing } --TODO use timeout
+                          case mconn of
+                            Left  err  -> throw err
+                            Right conn -> do
+                              NT.send conn [controlHeaderBidirectionalAck nonce]
+                              handlerInOut peer (ChannelIn chan) (ChannelOut conn)
+                                  `finally`
+                                  closeChannel (ChannelOut conn)
+                  tid <- fork $ finishHandler (Left connid) action
+                  pure . Just $ ConnectionReceiving tid chan
+
+                -- We want a bidirectional connection and the
+                -- peer has acknowledged. Check that their nonce
+                -- matches what we sent and if so start writing
+                -- to the channel associated with that nonce.
+                -- See connectInOutChannel/withInOutChannel for the other half
+                -- of the story (where we send SYNs and record
+                -- nonces).
+                --
+                -- A call to withInOutChannel ensures that when the action using
+                -- the in/out channel completes, it will update the shared
+                -- atomic 'finished' variable to indicate that thread
+                -- corresponding to the *nonce* is completed. It may have
+                -- already completed at this point, which is weird but not
+                -- out of the question (the handler didn't ask to receive
+                -- anything). 
+                --
+                | w == controlHeaderCodeBidirectionalAck
+                , Right (ws',_,nonce) <- decodeOrFail ws -> do
+                  (tid, ChannelIn chan) <- modifySharedAtomic nodeState $ \(prng, expected, finished) ->
+                      case Map.lookup nonce expected of
+                          Nothing -> throw (ProtocolError $ "unexpected ack nonce " ++ show nonce)
+                          Just (NonceHandlerNotConnected tid inchan) -> do
+                              let !expected' = Map.insert nonce (NonceHandlerConnected connid) expected
+                              return ((prng, expected', finished), (tid, inchan))
+                          Just _ -> throw (InternalError $ "duplicate or delayed ACK for " ++ show nonce)
+                  mapM_ (Channel.writeChannel chan . Just) (LBS.toChunks ws')
+                  pure . Just $ ConnectionReceiving tid chan
+
+                | otherwise ->
+                    throw (ProtocolError $ "unexpected control header " ++ show w)
 
     loop :: DispatcherState m -> m ()
     loop !state = do
-      !state <- clearDeadThreads state
+      !state <- updateStateForFinishedHandlers state
       event <- NT.receive endpoint
       case event of
 
           NT.ConnectionOpened connid NT.ReliableOrdered peer ->
-            -- Just keep track of the new connection, nothing else
-            loop (Map.insert connid (ConnectionNew (NodeId peer)) state)
+              -- Just keep track of the new connection, nothing else
+              loop (Map.insert connid (ConnectionNew (NodeId peer)) state)
 
           -- receiving data for an existing connection (ie a multi-chunk message)
           NT.Received connid chunks ->
-            case Map.lookup connid state of
-              Nothing ->
-                throw (InternalError "received data on unknown connection")
+              case Map.lookup connid state of
+                  Nothing ->
+                      throw (InternalError "received data on unknown connection")
 
-              -- TODO: need policy here on queue size
-              Just (ConnectionNew peer) ->
-               loop (Map.insert connid (ConnectionNewChunks peer chunks) state)
+                  -- TODO: need policy here on queue size
+                  Just (ConnectionNew peer) ->
+                      loop (Map.insert connid (ConnectionNewChunks peer chunks) state)
 
-              -- fork a new thread with a new queue filled with the first data chunks
-              Just (ConnectionNewChunks peer@(NodeId peerEndpointAddr) chunks0) ->
-                case LBS.uncons (LBS.fromChunks (chunks0 ++ chunks)) of
-                  Nothing -> loop state -- all empty, wait for more data
-                  Just (w, ws)
-                    | w == controlHeaderCodeUnidirectional -> do
-                      chan <- Channel.newChannel
-                      mapM_ (Channel.writeChannel chan . Just) (LBS.toChunks ws)
-                      tid  <- fork $ reportConnidAndException connid (handlerIn peer (ChannelIn chan))
-                      loop (Map.insert connid (ConnectionReceiving tid chan) state)
+                  Just (ConnectionNewChunks peer@(NodeId peerEndpointAddr) chunks0) -> do
+                      mConnState <- handleFirstChunks connid peer (chunks0 ++ chunks) state
+                      loop (maybe state (\cs -> Map.insert connid cs state) mConnState)
 
-                    | w == controlHeaderCodeBidirectionalAck ||
-                      w == controlHeaderCodeBidirectionalSyn
-                    , LBS.length ws < 8 -> -- need more data
-                      loop (Map.insert connid (ConnectionNewChunks peer (chunks0 ++ chunks)) state)
+                  -- Connection is receiving data and there's some handler
+                  -- at 'tid' to run it. Dump the new data to its ChannelIn.
+                  Just (ConnectionReceiving tid chan) -> do
+                    mapM_ (Channel.writeChannel chan . Just) chunks
+                    loop state
 
-                    | w == controlHeaderCodeBidirectionalSyn
-                    , Right (ws',_,nonce) <- decodeOrFail ws -> do
-                      chan <- Channel.newChannel
-                      mapM_ (Channel.writeChannel chan . Just) (LBS.toChunks ws')
-                      let action = do
-                              mconn <- NT.connect
-                                         endpoint
-                                         peerEndpointAddr
-                                         NT.ReliableOrdered
-                                         NT.ConnectHints{ connectTimeout = Nothing } --TODO use timeout
-                              case mconn of
-                                Left  err  -> throw err
-                                Right conn -> do
-                                  NT.send conn [controlHeaderBidirectionalSyn nonce]
-                                  handlerInOut peer (ChannelIn chan) (ChannelOut conn)
-                      tid <- fork $ reportConnidAndException connid action
-                      loop (Map.insert connid (ConnectionReceiving tid chan) state)
+                  Just (ConnectionClosed tid) ->
+                    throw (InternalError "received data on closed connection")
 
-
-                    | w == controlHeaderCodeBidirectionalAck
-                    , Right (ws',_,nonce) <- decodeOrFail ws -> do
-                      (tid, ChannelIn chan) <- modifySharedAtomic incomingVar $ \(prng, expected) ->
-                        case Map.lookup nonce expected of
-                          Nothing -> throw (ProtocolError $ "unexpected ack nonce " ++ show nonce)
-                          Just info -> do
-                            let !expected' = Map.delete nonce expected
-                            return ((prng, expected'), info)
-                      mapM_ (Channel.writeChannel chan . Just) (LBS.toChunks ws')
-                      loop (Map.insert connid (ConnectionReceiving tid chan) state)
-
-                    | otherwise ->
-                        throw (ProtocolError $ "unexpected control header " ++ show w)
-
-              Just (ConnectionReceiving tid chan) -> do
-                mapM_ (Channel.writeChannel chan . Just) chunks
-                loop state
-
-              Just (ConnectionClosed tid) ->
-                throw (InternalError "received data on closed connection")
+                  -- The peer keeps pushing data but our handler is finished.
+                  -- What to do? Would like to close the connection but I'm
+                  -- not sure that's possible in network-transport. Would like
+                  -- to say "stop receiving on this ConnectionId".
+                  -- We could maintain an association between ConnectionId and
+                  -- EndPointId of the peer, and then maybe patch
+                  -- network-transport to allow for selective closing of peer
+                  -- connection based on EndPointAddress.
+                  Just (ConnectionHandlerFinished maybeException) ->
+                    throw (InternalError "received too much data")
 
           NT.ConnectionClosed connid ->
-            case Map.lookup connid state of
-              Nothing ->
-                throw (InternalError "closed unknown connection")
+              case Map.lookup connid state of
+                  Nothing ->
+                      throw (InternalError "closed unknown connection")
 
-              -- empty message
-              Just (ConnectionNew peer) -> do
-                chan <- Channel.newChannel
-                Channel.writeChannel chan Nothing
-                tid  <- fork $ reportConnidAndException connid (handlerIn peer (ChannelIn chan))
-                loop (Map.insert connid (ConnectionClosed tid) state)
+                  -- Connection closed, handler already finished. We're done
+                  -- with the connection. The case in which the handler finishes
+                  -- *after* the connection closes is taken care of in
+                  -- 'updateStateForFinishedHandlers'.
+                  Just (ConnectionHandlerFinished _) ->
+                      loop (Map.delete connid state)
 
-              -- small message
-              Just (ConnectionNewChunks peer chunks0) -> do
-                chan <- Channel.newChannel
-                mapM_ (Channel.writeChannel chan . Just) chunks0
-                Channel.writeChannel chan Nothing
-                tid  <- fork $ reportConnidAndException connid (handlerIn peer (ChannelIn chan))
-                loop (Map.insert connid (ConnectionClosed tid) state)
+                  -- Empty message
+                  Just (ConnectionNew peer) -> do
+                      chan <- Channel.newChannel
+                      Channel.writeChannel chan Nothing
+                      tid  <- fork $ finishHandler (Left connid) (handlerIn peer (ChannelIn chan))
+                      loop (Map.insert connid (ConnectionClosed tid) state)
 
-              Just (ConnectionReceiving tid chan) -> do
-                Channel.writeChannel chan Nothing
-                loop (Map.insert connid (ConnectionClosed tid) state)
+                  -- Small message
+                  Just (ConnectionNewChunks peer chunks0) -> do
+                      mConnState <- handleFirstChunks connid peer chunks0 state
+                      case mConnState of
+                          Just (ConnectionReceiving tid chan) -> do
+                              -- Write Nothing to indicate end of input.
+                              Channel.writeChannel chan Nothing
+                              loop (Map.insert connid (ConnectionClosed tid) state)
+                          _ -> throw (InternalError "malformed small message")
 
-              Just (ConnectionClosed tid) ->
-                throw (InternalError "closed a closed connection")
+                  -- End of incoming data. Signal that by writing 'Nothing'
+                  -- to the ChannelIn.
+                  Just (ConnectionReceiving tid chan) -> do
+                      Channel.writeChannel chan Nothing
+                      loop (Map.insert connid (ConnectionClosed tid) state)
 
+                  Just (ConnectionClosed tid) ->
+                      throw (InternalError "closed a closed connection")
 
           NT.EndPointClosed ->
-            --TODO: decide what to do with all active handlers
-            return ()
+              -- TODO: decide what to do with all active handlers
+              -- Throw them a special exception?
+              return ()
 
-          NT.ErrorEvent (NT.TransportError (NT.EventErrorCode (NT.EventConnectionLost peer)) _msg) -> undefined
+          NT.ErrorEvent (NT.TransportError (NT.EventErrorCode (NT.EventConnectionLost peer)) _msg) ->
+              throw (InternalError "Connection lost")
 
-          NT.ErrorEvent (NT.TransportError (NT.EventErrorCode NT.EventEndPointFailed)  msg) -> undefined
+          NT.ErrorEvent (NT.TransportError (NT.EventErrorCode NT.EventEndPointFailed)  msg) ->
+              throw (InternalError "EndPoint failed")
 
-          NT.ErrorEvent (NT.TransportError (NT.EventErrorCode NT.EventTransportFailed) msg) -> undefined
+          NT.ErrorEvent (NT.TransportError (NT.EventErrorCode NT.EventTransportFailed) msg) ->
+              throw (InternalError "Transport failed")
 
-          NT.ErrorEvent (NT.TransportError NT.UnsupportedEvent msg) -> undefined
+          NT.ErrorEvent (NT.TransportError NT.UnsupportedEvent msg) ->
+              throw (InternalError "Unsupported event")
 
           NT.ConnectionOpened _ _ _ ->
-            throw (ProtocolError "unexpected connection reliability")
+              throw (ProtocolError "unexpected connection reliability")
 
+-- TBD would we ever want to use this? It doesn't send the control header to
+-- establish a unidirectional flow.
 sendMsg :: forall m . ( Monad m ) => Node m -> NodeId -> LBS.ByteString -> m ()
 sendMsg Node{nodeEndPoint} (NodeId endpointaddr) msg = do
     mconn <- NT.connect
@@ -363,8 +512,8 @@ connectInOutChannel
        , Mockable Throw m )
     => Node m
     -> NodeId
-    -> m (ChannelIn m, ChannelOut m)
-connectInOutChannel node@Node{nodeEndPoint, nodeExpectedIncoming}
+    -> m (Nonce, ChannelIn m, ChannelOut m)
+connectInOutChannel node@Node{nodeEndPoint, nodeState}
                     nodeid@(NodeId endpointaddr) = do
     mconn <- NT.connect
                nodeEndPoint
@@ -380,15 +529,19 @@ connectInOutChannel node@Node{nodeEndPoint, nodeExpectedIncoming}
       Right outconn -> do
         (nonce, inchan) <- allocateInChannel
         NT.send outconn [controlHeaderBidirectionalSyn nonce]
-        return (ChannelIn inchan, ChannelOut outconn)
+        return (nonce, ChannelIn inchan, ChannelOut outconn)
   where
+    -- FIXME remove the nonce from the map and cleanup if timed out.
+    -- That's probably the dispatcher's responsibility.
     allocateInChannel = do
       tid   <- myThreadId
       chan  <- Channel.newChannel
-      nonce <- modifySharedAtomic nodeExpectedIncoming $ \(prng, expected) -> do
+      -- Create a nonce and update the shared atomic so that the nonce indicates
+      -- that there's a handler for it.
+      nonce <- modifySharedAtomic nodeState $ \(prng, expected, finished) -> do
                  let (nonce, !prng') = random prng
-                     !expected' = Map.insert nonce (tid, ChannelIn chan) expected
-                 pure ((prng', expected), nonce)
+                     !expected' = Map.insert nonce (NonceHandlerNotConnected tid (ChannelIn chan)) expected
+                 pure ((prng', expected', finished), nonce)
       return (nonce, chan)
 
 connectOutChannel
@@ -415,17 +568,42 @@ connectOutChannel Node{nodeEndPoint} (NodeId endpointaddr) = do
 closeChannel :: ChannelOut m -> m ()
 closeChannel (ChannelOut conn) = NT.close conn
 
+-- | Create a conversation channel with a given peer (NodeId) and run some
+--   actions against its in/out channels. This is the only way to start a
+--   conversation.
 withInOutChannel
-    :: ( Mockable Bracket m, Mockable Fork m, Mockable Channel.Channel m
-       , Mockable SharedAtomic m, Mockable Throw m )
+    :: forall m a .
+       ( Mockable Bracket m, Mockable Fork m, Mockable Channel.Channel m
+       , Mockable SharedAtomic m, Mockable Throw m, Mockable Catch m )
     => Node m
     -> NodeId
     -> (ChannelIn m -> ChannelOut m -> m a)
     -> m a
-withInOutChannel node nodeid action =
+withInOutChannel node@Node{nodeState} nodeid action =
+    -- connectInOurChannel will update the nonce state to indicate that there's
+    -- a handler for it. When the handler is finished (whether normally or
+    -- exceptionally) we have to update it to say so.
     bracket (connectInOutChannel node nodeid)
-            (\(_, outchan) -> closeChannel outchan)
-            (\(inchan, outchan) -> action inchan outchan)
+            (\(_, _, outchan) -> closeChannel outchan)
+            (\(nonce, inchan, outchan) -> action' nonce inchan outchan)
+    where
+    -- Updates the nonce state map always, and re-throws any caught exception.
+    action' nonce inchan outchan =
+        normal nonce inchan outchan
+        `catch`
+        exceptional nonce
+    normal nonce inchan outchan = do
+        a <- action inchan outchan
+        modifySharedAtomic nodeState $ \(prng, map, finished) -> do
+            -- We don't delete the nonce from the map here. The dispatcher
+            -- thread does that.
+            -- Why? It's probably inconsequential...
+            pure ((prng, map, (Right nonce, Nothing) : finished), ())
+        pure a
+    exceptional nonce (e :: SomeException) = do
+        modifySharedAtomic nodeState $ \(prng, map, finished) -> do
+            pure ((prng, map, (Right nonce, Just e) : finished), ())
+        throw e
 
 withOutChannel
     :: ( Mockable Bracket m, Mockable Throw m )
@@ -436,8 +614,13 @@ withOutChannel
 withOutChannel node nodeid =
     bracket (connectOutChannel node nodeid) closeChannel
 
+-- | Write some ByteStrings to an out channel. It does not close the
+--   transport when finished. If you want that, try this motif:
+--
+--     withOutChannel node nodeId $ \out -> writeChannel out bss
+--
 writeChannel :: ( Monad m ) => ChannelOut m -> [BS.ByteString] -> m ()
-writeChannel (ChannelOut conn) [] = NT.close conn
+writeChannel (ChannelOut conn) [] = pure ()
 writeChannel (ChannelOut conn) (chunk:chunks) = do
     res <- NT.send conn [chunk]
     -- Any error detected here will be reported to the dispatcher thread


### PR DESCRIPTION
This includes a 'discovery' abstraction and an implementation of it with Kademlia (demonstration in `examples/Discovery.hs`, as well as support for bidirectional connections (demonstration in `examples/PingPong.hs`).