### PR TITLE
Concatenate chunks before attempting to parse

### DIFF
--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -6,7 +6,9 @@
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE DeriveGeneric         #-}
 
+import           GHC.Generics                         (Generic)
 import           Control.Monad                        (forM, forM_, when)
 import           Control.Monad.IO.Class               (liftIO)
 import           Data.Binary
@@ -27,14 +29,9 @@ import           System.Environment                   (getArgs)
 import           System.Random
 
 data Pong = Pong
+deriving instance Generic Pong
 deriving instance Show Pong
-instance Binary Pong where
-    put _ = putWord8 (fromIntegral 1)
-    get = do
-        w <- getWord8
-        if w == fromIntegral 1
-        then pure Pong
-        else fail "no parse pong"
+instance Binary Pong
 
 type Header = ()
 

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -6,7 +6,9 @@
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE DeriveGeneric         #-}
 
+import           GHC.Generics               (Generic)
 import           Control.Monad              (forM_)
 import           Control.Monad.IO.Class     (liftIO)
 import           Data.Binary
@@ -30,25 +32,15 @@ import           System.Random
 
 -- | Type for messages from the workers to the listeners.
 data Ping = Ping
+deriving instance Generic Ping
 deriving instance Show Ping
-instance Binary Ping where
-    put _ = putWord8 (fromIntegral 1)
-    get = do
-        w <- getWord8
-        if w == fromIntegral 1
-        then pure Ping
-        else fail "no parse ping"
+instance Binary Ping
 
 -- | Type for messages from the listeners to the workers.
 data Pong = Pong
+deriving instance Generic Pong
 deriving instance Show Pong
-instance Binary Pong where
-    put _ = putWord8 (fromIntegral 1)
-    get = do
-        w <- getWord8
-        if w == fromIntegral 1
-        then pure Pong
-        else fail "no parse pong"
+instance Binary Pong
 
 type Header = ()
 


### PR DESCRIPTION
This is the one true way. See the discussion here:
https://github.com/haskell-distributed/network-transport-tcp/pull/44

network-transport only guarantees that
`concat sentChunks == concat receivedChunks`
which neatly handles the case of `[]` as `concat [] = ""`.

Types which serialize to `""` are now acceptable.