### PR TITLE
Add Async mocking; change node start/stop; some questions about time/delay mocking

### DIFF
--- a/bench/Network/Common/Bench/Network/Commons.hs
+++ b/bench/Network/Common/Bench/Network/Commons.hs
@@ -24,6 +24,7 @@ module Bench.Network.Commons
 
 import           Control.Applicative    ((<|>))
 import qualified Control.Concurrent     as Conc
+import qualified Control.Concurrent.Async as Conc
 import qualified Control.Concurrent.STM as Conc
 import qualified Control.Exception      as Exception
 import           Control.Monad          (join)
@@ -206,6 +207,14 @@ instance Mockable Fork (LoggerNameBox IO) where
 instance Mockable RunInUnboundThread (LoggerNameBox IO) where
     liftMockable (RunInUnboundThread m) = getLoggerName >>=
         \lname -> lift $ Conc.runInUnboundThread $ usingLoggerName lname m
+
+type instance Promise (LoggerNameBox IO) = Conc.Async
+
+instance Mockable Async (LoggerNameBox IO) where
+    liftMockable (Async m) = getLoggerName >>=
+        \lname -> lift $ Conc.async $ usingLoggerName lname m
+    liftMockable (Wait promise) = lift $ Conc.wait promise
+    liftMockable (Cancel promise) = lift $ Conc.cancel promise
 
 type instance SharedAtomicT (LoggerNameBox IO) = Conc.MVar
 

--- a/bench/Network/Receiver/Main.hs
+++ b/bench/Network/Receiver/Main.hs
@@ -26,7 +26,7 @@ import Message.Message            (BinaryP (..))
 import Network.Transport.Abstract (newEndPoint)
 import Network.Transport.Concrete (concrete)
 import Node                       (Listener (..), ListenerAction (..), sendTo,
-                                   node)
+                                   node, NodeAction(..))
 import ReceiverOptions            (Args (..), argsParser)
 
 instance Mockable Catch (LoggerNameBox IO) where
@@ -52,8 +52,9 @@ main = do
     let prng = mkStdGen 0
 
     usingLoggerName "receiver" $ do
-        node transport prng BinaryP (\_ -> [Listener "ping" $ pingListener noPong]) $ \nodeId sactions -> do
-            threadDelay (fromIntegral duration :: Second)
+        node transport prng BinaryP $ \node ->
+            pure $ NodeAction [Listener "ping" $ pingListener noPong] $ \sactions -> do
+                threadDelay (fromIntegral duration :: Second)
   where
     pingListener noPong =
         -- TODO: `ListenerActionConversation` is not supported in such context

--- a/bench/Network/Receiver/Main.hs
+++ b/bench/Network/Receiver/Main.hs
@@ -25,8 +25,8 @@ import Bench.Network.Commons      (MeasureEvent (..), Ping (..), Pong (..), load
 import Message.Message            (BinaryP (..))
 import Network.Transport.Abstract (newEndPoint)
 import Network.Transport.Concrete (concrete)
-import Node                       (Listener (..), ListenerAction (..), sendTo, startNode,
-                                   stopNode)
+import Node                       (Listener (..), ListenerAction (..), sendTo,
+                                   node)
 import ReceiverOptions            (Args (..), argsParser)
 
 instance Mockable Catch (LoggerNameBox IO) where
@@ -52,12 +52,8 @@ main = do
     let prng = mkStdGen 0
 
     usingLoggerName "receiver" $ do
-        Right endPoint <- newEndPoint transport
-        receiverNode <- startNode endPoint prng BinaryP []
-            [Listener "ping" $ pingListener noPong]
-
-        threadDelay (fromIntegral duration :: Second)
-        stopNode receiverNode
+        node transport prng BinaryP (\_ -> [Listener "ping" $ pingListener noPong]) $ \nodeId sactions -> do
+            threadDelay (fromIntegral duration :: Second)
   where
     pingListener noPong =
         -- TODO: `ListenerActionConversation` is not supported in such context

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -10,7 +10,6 @@
 
 import           Control.Monad                        (forM, forM_, when)
 import           Control.Monad.IO.Class               (liftIO)
-import           Control.TimeWarp.Timed               (for)
 import           Data.Binary
 import qualified Data.ByteString.Char8                as B8
 import qualified Data.Set                             as S
@@ -19,7 +18,9 @@ import           Data.Time.Units                      (Microsecond, fromMicrosec
 import           Data.Void                            (Void)
 import           GHC.Generics                         (Generic)
 import           Message.Message                      (BinaryP (..))
-import           Mockable.Concurrent                  (wait)
+import           Mockable.Concurrent                  (delay, for, fork, killThread,
+                                                       ThreadId)
+import           Mockable.Exception                   (finally)
 import           Mockable.Production
 import           Network.Discovery.Abstract
 import qualified Network.Discovery.Transport.Kademlia as K
@@ -37,8 +38,8 @@ instance Binary Pong where
 
 type Packing = BinaryP
 
-workers :: NodeId -> StdGen -> NetworkDiscovery K.KademliaDiscoveryErrorCode Production -> [Worker Packing Production]
-workers anId generator discovery = [pingWorker generator]
+worker :: NodeId -> StdGen -> NetworkDiscovery K.KademliaDiscoveryErrorCode Production -> Worker Packing Production
+worker anId generator discovery = pingWorker generator
     where
     pingWorker :: StdGen -> SendActions Packing Production -> Production ()
     pingWorker gen sendActions = loop gen
@@ -46,7 +47,7 @@ workers anId generator discovery = [pingWorker generator]
         loop g = do
             let (i, gen') = randomR (1000,2000000) g
                 us = fromMicroseconds i :: Microsecond
-            wait $ for us
+            delay (for us)
             _ <- knownPeers discovery
             _ <- discoverPeers discovery
             peerSet <- knownPeers discovery
@@ -69,8 +70,7 @@ listeners anId = [Listener (fromString "ping") pongListener]
 
 makeNode :: Transport Production
          -> Int
-         -> Production (Node Production,
-                        NetworkDiscovery K.KademliaDiscoveryErrorCode Production)
+         -> Production (ThreadId Production)
 makeNode transport i = do
     let port = 3000 + i
     let host = "127.0.0.1"
@@ -85,14 +85,10 @@ makeNode transport i = do
     let prng1 = mkStdGen (2 * i)
     let prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i
-    Right endPoint <- newEndPoint transport
-    rec { node <- startNode endPoint prng1 BinaryP (workers (nodeId node) prng2 discovery)
-            (listeners (nodeId node))
-        ; let localAddress = nodeEndPointAddress node
-        ; liftIO . putStrLn $ "Making discovery for node " ++ show i
-        ; discovery <- K.kademliaDiscovery kademliaConfig initialPeer localAddress
-        }
-    pure (node, discovery)
+    fork $ node transport prng1 BinaryP (listeners . nodeId) $ \node sactions -> do
+        liftIO . putStrLn $ "Making discovery for node " ++ show i
+        discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node)
+        worker (nodeId node) prng2 discovery sactions `finally` closeDiscovery discovery
     where
     makeId anId
         | anId < 10 = B8.pack ("node_identifier_0" ++ show anId)
@@ -110,10 +106,10 @@ main = runProduction $ do
     let transport = concrete transport_
 
     liftIO . putStrLn $ "Spawning " ++ show number ++ " nodes"
-    nodesAndDiscoveries <- forM [0..number] (makeNode transport)
+    nodeThreads <- forM [0..number] (makeNode transport)
 
     liftIO $ putStrLn "Hit return to stop"
     _ <- liftIO $ getChar
 
     liftIO $ putStrLn "Stopping nodes"
-    forM_ nodesAndDiscoveries (\(n, d) -> stopNode n >> closeDiscovery d)
+    forM_ nodeThreads killThread

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -85,10 +85,11 @@ makeNode transport i = do
     let prng1 = mkStdGen (2 * i)
     let prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i
-    fork $ node transport prng1 BinaryP (listeners . nodeId) $ \node sactions -> do
-        liftIO . putStrLn $ "Making discovery for node " ++ show i
-        discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node)
-        worker (nodeId node) prng2 discovery sactions `finally` closeDiscovery discovery
+    fork $ node transport prng1 BinaryP $ \node -> do
+        pure $ NodeAction (listeners . nodeId $ node) $ \sactions -> do
+            liftIO . putStrLn $ "Making discovery for node " ++ show i
+            discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node)
+            worker (nodeId node) prng2 discovery sactions `finally` closeDiscovery discovery
     where
     makeId anId
         | anId < 10 = B8.pack ("node_identifier_0" ++ show anId)

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -63,6 +63,7 @@ Library
                       , time-units
                       , time-warp
                       , transformers
+                      , async
   hs-source-dirs:       src
   default-language:     Haskell2010
   ghc-options:          -Wall
@@ -149,6 +150,7 @@ executable bench-sender
                      , time-units >= 1.0.0
                      , transformers >= 0.5.2
                      , unordered-containers >= 0.2.7
+                     , async
   hs-source-dirs:      bench/Network/Sender
                      , bench/Network/Common
   if flag(benchmarks)
@@ -190,6 +192,7 @@ executable bench-receiver
                      , time >= 1.6
                      , time-units >= 1.0.0
                      , unordered-containers >= 0.2.7
+                     , async
   hs-source-dirs:      bench/Network/Receiver
                      , bench/Network/Common
   if flag(benchmarks)
@@ -232,6 +235,9 @@ executable bench-log-reader
                      , time >= 1.6
                      , time-units >= 1.0.0
                      , unordered-containers >= 0.2.7
+                     , conduit
+                     , conduit-extra
+                     , async
   hs-source-dirs:      bench/Network/LogReader
                      , bench/Network/Common
   if flag(benchmarks)

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -269,6 +269,7 @@ test-suite node-sketch-test
                      , random
                      , serokell-util >= 0.1.2.3
                      , stm
+                     , time-units
   hs-source-dirs:      test
   default-language:    Haskell2010
   ghc-options:         -threaded

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -61,7 +61,6 @@ Library
                       , text
                       , time
                       , time-units
-                      , time-warp
                       , transformers
                       , async
   hs-source-dirs:       src
@@ -84,7 +83,6 @@ executable discovery
                       , node-sketch
                       , random
                       , time-units
-                      , time-warp
 
   hs-source-dirs:       examples
   default-language:     Haskell2010
@@ -105,7 +103,6 @@ executable ping-pong
                      , random
                      , stm
                      , time-units
-                     , time-warp
 
   hs-source-dirs:      examples
   default-language:    Haskell2010
@@ -272,7 +269,6 @@ test-suite node-sketch-test
                      , random
                      , serokell-util >= 0.1.2.3
                      , stm
-                     , time-warp
   hs-source-dirs:      test
   default-language:    Haskell2010
   ghc-options:         -threaded

--- a/src/Mockable/Concurrent.hs
+++ b/src/Mockable/Concurrent.hs
@@ -20,6 +20,12 @@ module Mockable.Concurrent (
   , RunInUnboundThread(..)
   , runInUnboundThread
 
+  , Promise
+  , Async(..)
+  , async
+  , wait
+  , cancel
+
   ) where
 
 import Mockable.Class
@@ -73,3 +79,19 @@ data RunInUnboundThread m t where
 
 runInUnboundThread :: ( Mockable RunInUnboundThread m ) => m t -> m t
 runInUnboundThread m = liftMockable $ RunInUnboundThread m
+
+type family Promise (m :: * -> *) :: * -> *
+
+data Async m t where
+    Async :: m t -> Async m (Promise m t)
+    Wait :: Promise m t -> Async m t
+    Cancel :: Promise m t -> Async m ()
+
+async :: ( Mockable Async m ) => m t -> m (Promise m t)
+async m = liftMockable $ Async m
+
+wait :: ( Mockable Async m ) => Promise m t -> m t
+wait promise = liftMockable $ Wait promise
+
+cancel :: ( Mockable Async m ) => Promise m t -> m ()
+cancel promise = liftMockable $ Cancel promise

--- a/src/Mockable/Monad.hs
+++ b/src/Mockable/Monad.hs
@@ -9,14 +9,13 @@ module Mockable.Monad
 
 import Mockable.Channel      (Channel)
 import Mockable.Class
-import Mockable.Concurrent   (Delay, Fork, RepeatForever)
+import Mockable.Concurrent   (Delay, Fork)
 import Mockable.Exception    (Bracket, Catch, Throw)
 import Mockable.SharedAtomic (SharedAtomic)
 
 -- | Bunch of Mockable-constraints.
 type MonadMockable m
     = ( Mockable Delay m
-      , Mockable RepeatForever m
       , Mockable SharedAtomic m
       , Mockable Fork m
       , Mockable Bracket m

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -54,6 +54,10 @@ instance Mockable Async Production where
     liftMockable (Wait promise) = Production $ Conc.wait promise
     liftMockable (Cancel promise) = Production $ Conc.cancel promise
 
+instance Mockable Concurrently Production where
+    liftMockable (Concurrently a b) = Production $
+        Conc.concurrently (runProduction a) (runProduction b)
+
 type instance SharedAtomicT Production = Conc.MVar
 
 instance Mockable SharedAtomic Production where

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -70,6 +70,13 @@ instance Mockable RunInUnboundThread Production where
     liftMockable (RunInUnboundThread m) = Production $
         Conc.runInUnboundThread (runProduction m)
 
+type instance Promise Production = Conc.Async
+
+instance Mockable Async Production where
+    liftMockable (Async m) = Production $ Conc.async (runProduction m)
+    liftMockable (Wait promise) = Production $ Conc.wait promise
+    liftMockable (Cancel promise) = Production $ Conc.cancel promise
+
 type instance SharedAtomicT Production = Conc.MVar
 
 instance Mockable SharedAtomic Production where

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -6,13 +6,14 @@
 module Mockable.Production where
 
 import qualified Control.Concurrent          as Conc
+import qualified Control.Concurrent.Async    as Conc
 import qualified Control.Concurrent.STM      as Conc
 import           Control.Concurrent.STM.TVar (newTVarIO, readTVarIO, writeTVar)
 import qualified Control.Exception           as Exception
 import           Control.Monad               (forever, void)
 import           Control.Monad.Fix           (MonadFix)
 import           Control.Monad.IO.Class      (MonadIO, liftIO)
-import           Control.TimeWarp.Timed      (Microsecond, for, hour, ms)
+import           Data.Time.Units             (Microsecond)
 import           Data.Time.Clock.POSIX       (getPOSIXTime)
 import           Mockable.Channel
 import           Mockable.Class
@@ -41,30 +42,6 @@ instance Mockable Delay Production where
     liftMockable (Delay relativeToNow) = Production $ do
         cur <- runProduction $ curTime
         Conc.threadDelay $ fromIntegral $ relativeToNow cur - cur
-    liftMockable SleepForever = forever . wait $ for 24 hour
-
-instance Mockable RepeatForever Production where
-    liftMockable (RepeatForever period handler action) = do
-        timer <- startTimer
-        nextDelay <- liftIO $ newTVarIO Nothing
-        void $ fork $
-            let setNextDelay = liftIO . Conc.atomically . writeTVar nextDelay . Just
-                action'      = action >> timer >>= \passed -> setNextDelay (period - passed)
-                handler' e   = handler e >>= setNextDelay
-            in action' `catch` handler'
-        waitForRes nextDelay
-      where
-        startTimer = do
-            start <- curTime
-            return $ subtract start <$> curTime
-
-        continue = repeatForever period handler action
-        waitForRes nextDelay = do
-            wait $ for 10 ms
-            res <- liftIO $ readTVarIO nextDelay
-            case res of
-                Nothing -> waitForRes nextDelay
-                Just t  -> wait (for t) >> continue
 
 instance Mockable RunInUnboundThread Production where
     liftMockable (RunInUnboundThread m) = Production $

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -19,7 +19,6 @@ module Test.Util
        , mkTestState
        , expected
        , fails
-       , activeWorkers
        , modifyTestState
        , addFail
        , newWork
@@ -31,7 +30,6 @@ module Test.Util
        , deliveryTest
        ) where
 
-import           Control.TimeWarp.Timed      (for, mcs)
 import           Control.Concurrent.STM      (STM, atomically, check)
 import           Control.Concurrent.STM.TVar (TVar, newTVarIO, readTVar, writeTVar)
 import           Control.Exception           (Exception, SomeException (..))
@@ -46,7 +44,7 @@ import qualified Data.List                   as L
 import qualified Data.Set                    as S
 import           Data.Void                   (Void)
 import           GHC.Generics                (Generic)
-import           Mockable.Concurrent         (wait, fork)
+import           Mockable.Concurrent         (delay, fork, for, forConcurrently)
 import           Mockable.Exception          (catch, throw)
 import           Mockable.Production         (Production (..))
 import           Network.Transport.Abstract  (closeTransport, newEndPoint)
@@ -60,11 +58,12 @@ import           Test.QuickCheck.Gen         (choose)
 import           Test.QuickCheck.Modifiers   (getLarge)
 import           Test.QuickCheck.Property    (Testable (..), failed, reason, succeeded)
 
-import          Node                        (ConversationActions (..), Listener (..),
-                                            ListenerAction (..), MessageName, NodeId,
-                                            SendActions (..), Worker,
-                                            nodeId, startNode, stopNode)
+import           Node                        (ConversationActions (..), Listener (..),
+                                             ListenerAction (..), MessageName, NodeId,
+                                             SendActions (..), Worker,
+                                             nodeId, node, NodeAction(..))
 import          Message.Message (BinaryP (..))
+import          Data.Time.Units              (fromMicroseconds)
 
 -- * Parcel
 
@@ -102,14 +101,12 @@ instance Arbitrary HeavyParcel where
 data TestState = TestState
     { _fails         :: [String]
     , _expected      :: S.Set Parcel
-    , _activeWorkers :: Int
     }
 
 mkTestState :: TestState
 mkTestState = TestState
     { _fails         = []
     , _expected      = S.empty
-    , _activeWorkers = 0
     }
 
 makeLenses ''TestState
@@ -138,7 +135,6 @@ reportingFail testState actionName act = do
 newWork :: TVar TestState -> String -> Production () -> Production ()
 newWork testState workerName act = do
     reportingFail testState workerName act
-    modifyTestState testState $ activeWorkers -= 1
 
 
 -- * Misc
@@ -155,7 +151,7 @@ awaitSTM :: Int -> STM Bool -> Production ()
 awaitSTM time predicate = do
     tvar <- liftIO $ newTVarIO False
     void . fork $ do
-        wait $ for time mcs
+        delay $ for (fromMicroseconds . fromIntegral $ time)
         liftIO . atomically $ writeTVar tvar True
     liftIO . atomically $
         check =<< (||) <$> predicate <*> readTVar tvar
@@ -210,39 +206,35 @@ deliveryTest :: TVar TestState
              -> [Listener BinaryP Production]
              -> IO Property
 deliveryTest testState workers listeners = runProduction $ do
-    transport_ <- throwLeft $ liftIO $ TCP.createTransport "127.0.0.1" "10342" TCP.defaultTCPParameters
+    let tcpParams = TCP.defaultTCPParameters {
+              TCP.tcpReuseServerAddr = True
+            , TCP.tcpReuseClientAddr = True
+            }
+    transport_ <- throwLeft $ liftIO $ TCP.createTransport "127.0.0.1" "10342" tcpParams
     let transport = concrete transport_
-    endpoint1 <- throwLeft $ newEndPoint transport
-    endpoint2 <- throwLeft $ newEndPoint transport
 
     let prng1 = mkStdGen 0
     let prng2 = mkStdGen 1
 
     -- wait for sender or receiver to complete
     -- TODO: make receiver stop automatically when sender finishes
-    modifyTestState testState $ activeWorkers .= 1
 
     -- launch nodes
-    rec { cliNode  <- startNode endpoint1 prng1 BinaryP
-            (sequence workers servNodeId) []
-        ; servNode <- startNode endpoint2 prng2 BinaryP
-            [] listeners
-        ; let servNodeId = nodeId servNode
-        }
+    node transport prng1 BinaryP $ \clientNode ->
+        pure $ NodeAction [] $ \clientSendActions ->
+        node transport prng2 BinaryP $ \serverNode ->
+            pure $ NodeAction listeners $ \serverSendActions -> do
 
-    -- wait for all processes to stop
-    liftIO . atomically $
-        check . (== 0) . _activeWorkers =<< readTVar testState
+                forConcurrently workers $ \worker ->
+                    worker (nodeId serverNode) clientSendActions
 
-    -- wait for receiver to get everything, but not for too long
-    awaitSTM 1000000 $ S.null . _expected <$> readTVar testState
+                -- wait for receiver to get everything, but not for too long
+                awaitSTM 5000000 $ S.null . _expected <$> readTVar testState
 
-    -- stop nodes
-    mapM_ stopNode [cliNode, servNode]
     closeTransport transport
 
     -- wait till port gets free
-    wait $ for 10000 mcs
+    delay $ for (fromMicroseconds . fromIntegral $ 10000)
 
     -- form test results
     liftIO . atomically $


### PR DESCRIPTION
- `Async` mocking has been added. @georgeee has requested adding `mapConcurrently`. That can certainly be done and will be useful.
- `startNode` has been removed in favour of a function called `node` which doesn't spawn workers for you, but gives you a `Node m` and `SendActions m` to work with, shutting down the `Node m` automatically when your work is done.
- The dependency on `time-warp` has been removed. Surely we don't want this to depend on `time-warp`, since it's a rework of that package.
- I have some concerns about `repeatForever` and `sleepForever`. They can both be implemented in a simpler way in terms of other primitives, and I don't think `sleepForever` is a good idea at all. Let's discuss.