### PR TITLE
Dispatcher waits for handlers to finish

### DIFF
--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -41,6 +41,7 @@ Library
 
   other-modules:        NTP.Packet
                         NTP.Util
+                        Data.NonEmptySet
 
   build-depends:        async
                       , attoparsec
@@ -74,6 +75,8 @@ Library
                       , time-warp
                       , transformers
                       , unordered-containers
+                      , semigroups
+
   hs-source-dirs:       src
   default-language:     Haskell2010
   ghc-options:          -Wall -fno-warn-orphans

--- a/src/Data/NonEmptySet.hs
+++ b/src/Data/NonEmptySet.hs
@@ -1,0 +1,44 @@
+module Data.NonEmptySet (
+
+      NonEmptySet
+    , singleton
+    , insert
+    , delete
+    , deleteMany
+    , toList
+
+    ) where
+
+import           Data.Set (Set)
+import qualified Data.Set as S
+import           Data.List.NonEmpty (NonEmpty((:|)))
+import           Data.Foldable (foldrM)
+
+-- | A set (no duplicates) with at least one element.
+newtype NonEmptySet t = NonEmptySet (t, Set t)
+
+-- | Construct a 'NonEmptySet' by giving one element.
+singleton :: t -> NonEmptySet t
+singleton t = NonEmptySet (t, S.empty)
+
+-- | Extend a 'NonEmptySet' by adding one element.
+insert :: Ord t => t -> NonEmptySet t -> NonEmptySet t
+insert t (NonEmptySet (t', set)) = case t `compare` t' of
+    LT -> NonEmptySet (t, S.insert t' set)
+    _ -> NonEmptySet (t', S.insert t set)
+
+-- | Remove an element from a 'NonEmptySet'. If it's the only element of the
+--   set, 'Nothing' is given.
+delete :: Ord t => t -> NonEmptySet t -> Maybe (NonEmptySet t)
+delete t (NonEmptySet (t', set)) = case (t == t', S.minView set) of
+    (False, _) -> Just $ NonEmptySet (t', S.delete t set)
+    (True, Nothing) -> Nothing
+    (True, Just (t'', set')) -> Just (NonEmptySet (t'', set'))
+
+deleteMany :: Ord t => [t] -> NonEmptySet t -> Maybe (NonEmptySet t)
+deleteMany ts neset = foldrM delete neset ts
+
+-- | Forget the fact that a 'NonEmptySet' and construct a 'NonEmpty' list, in
+--   which duplicates *are* allowed.
+toList :: NonEmptySet t -> NonEmpty t
+toList (NonEmptySet (t, set)) = t :| S.toList set

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -110,11 +110,11 @@ data SendActions packing m = SendActions {
 
        -- | Establish a bi-direction conversation session with a node.
        withConnectionTo
-           :: forall snd rcv.
+           :: forall snd rcv t .
             ( Packable packing snd, Message snd, Unpackable packing rcv )
            => LL.NodeId
-           -> (ConversationActions snd rcv m -> m ())
-           -> m ()
+           -> (ConversationActions snd rcv m -> m t)
+           -> m t
      }
 
 data ConversationActions body rcv m = ConversationActions {
@@ -183,11 +183,11 @@ nodeSendActions nodeUnit packing =
                 ]
 
     nodeWithConnectionTo
-        :: forall snd rcv .
+        :: forall snd rcv t .
            ( Packable packing snd, Message snd, Unpackable packing rcv )
         => LL.NodeId
-        -> (ConversationActions snd rcv m -> m ())
-        -> m ()
+        -> (ConversationActions snd rcv m -> m t)
+        -> m t
     nodeWithConnectionTo = \nodeId f ->
         LL.withInOutChannel nodeUnit nodeId $ \inchan outchan -> do
             let msgName  = messageName (Proxy :: Proxy snd)

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -160,8 +160,8 @@ makeListenerIndex = foldr combine (M.empty, [])
 nodeSendActions
     :: forall m packing .
        ( Mockable Channel m, Mockable Throw m, Mockable Catch m
-       , Mockable Bracket m, Mockable Fork m, Mockable SharedAtomic m
-       , Packable packing MessageName )
+       , Mockable Bracket m, Mockable Async m, Mockable SharedAtomic m
+       , Packable packing MessageName, MonadFix m )
     => LL.Node m
     -> packing
     -> SendActions packing m

--- a/test/Test/NodeSpec.hs
+++ b/test/Test/NodeSpec.hs
@@ -17,6 +17,7 @@ import qualified Data.Set                    as S
 import           Test.Hspec                  (Spec, describe)
 import           Test.Hspec.QuickCheck       (prop)
 import           Test.QuickCheck             (Property, ioProperty)
+import           Test.QuickCheck.Modifiers   (NonEmptyList(..), getNonEmpty)
 import           Test.Util                   (HeavyParcel (..), Parcel (..),
                                               TalkStyle (..), TestState, deliveryTest,
                                               expected, mkTestState, modifyTestState,
@@ -40,9 +41,10 @@ prepareDeliveryTestState expectedParcels =
 
 plainDeliveryTest
     :: TalkStyle
-    -> [Parcel]
+    -> NonEmptyList Parcel
     -> Property
-plainDeliveryTest talkStyle parcels = ioProperty $ do
+plainDeliveryTest talkStyle neparcels = ioProperty $ do
+    let parcels = getNonEmpty neparcels
     testState <- prepareDeliveryTestState parcels
 
     let worker peerId sendActions = newWork testState "client" $
@@ -53,5 +55,5 @@ plainDeliveryTest talkStyle parcels = ioProperty $ do
 
     deliveryTest testState [worker] [listener]
 
-withHeavyParcels :: ([Parcel] -> Property) -> [HeavyParcel] -> Property
-withHeavyParcels testCase megaParcels = testCase (getHeavyParcel <$> megaParcels)
+withHeavyParcels :: (NonEmptyList Parcel -> Property) -> NonEmptyList HeavyParcel -> Property
+withHeavyParcels testCase (NonEmpty megaParcels) = testCase (NonEmpty (getHeavyParcel <$> megaParcels))


### PR DESCRIPTION
In this program:

```Haskell
node transport prng listeners $ \theNode -> do
    <some program>
    putStrLn "Closing"
putStrLn "Closed"
```

`"Closed"` will not be printed until every one of the node's running listeners has finished, and no new conversation handlers will be spun up *by the dispatcher* after "Closing" is printed (at which point the network-transport `EndPoint` created by `node` is closed, so we can't complete the SYN/ACK handshake).

NB: it s possible for the programmer to try to make new connections after the `EndPoint` has closed, for instance if threads are left running with `theNode` in scope after the monadic term given as the final argument of `node` finishes. When this is done, an exception is thrown.


I noticed that the conversation style test would sometimes fail. It happened when quickcheck chose to send 0 parcels, in which case the sender would send a SYN but the node program would finish before this event was processed and an ACK was sent back. The `EndPointClosed` event would go behind the `Received` event containing the SYN, so the dispatcher would pick it up and try to `ACK`, not aware that its `EndPoint` was closed. This patch fixes it: no handshake connection attempt is made if the node is finished and its `EndPoint` closed. I have also updated the tests so that

- QuickCheck never chooses 0 parcels
- When conversation is chosen, the sender always waits for a response from the receiver.

Even with that, the problem remained: an error event (`EventConnectionLost`) would sometimes come and blow up the dispatcher. But receiving this event is a normal thing, we simply had not got around to implementing that part of the dispatcher. Now it's here: when a connection is lost to a given `EndPointAddress`, we indicate to all handlers for connections to that `EndPointAddress` that there is no more data (sends by conversation listeners will fail with exceptions, sends by `SendActions` will try to establish new connections).